### PR TITLE
fix(infra): correct ALB HTTPS routing paths and app base URLs

### DIFF
--- a/docs/ops/incident-changes.md
+++ b/docs/ops/incident-changes.md
@@ -41,6 +41,44 @@ aws ec2 create-vpc --cidr-block 10.0.0.0/16
 
 ## Change History
 
+### 2026-02-17 - Fix ALB HTTPS Routing for Saleor Apps
+
+**Incident:** All 5 Saleor apps returning 404 in staging — not accessible from dashboard
+**Responder:** Michael + PAI (Gen)
+**Time:** 2026-02-17
+
+**Root Cause:**
+When HTTPS host-based routing was added (2026-02-14), the ALB listener rules for apps used incorrect path patterns. The HTTPS rules matched `/stripe/*`, `/inventory-ops/*`, etc., but the apps are built with `BASE_PATH=/apps/stripe`, `/apps/inventory`, etc. Requests to `/apps/stripe/*` fell through to the default rule (storefront), returning a Next.js 404.
+
+**Changes Made:**
+```bash
+# Modified 5 ALB HTTPS listener rules to match actual app BASE_PATH values:
+# Priority 200: /stripe/* → /apps/stripe/*
+# Priority 210: /inventory-ops/* → /apps/inventory/*
+# Priority 220: /buylist/* → /apps/buylist/*
+# Priority 230: /pos/* → /apps/pos/*
+# Priority 240: /mtg-import/* → /apps/mtg-import/*
+
+aws elbv2 modify-rule --rule-arn <rule-arn> --conditions '[
+  {"Field":"host-header","HostHeaderConfig":{"Values":["apps.staging.michaelbean.org"]}},
+  {"Field":"path-pattern","PathPatternConfig":{"Values":["/apps/<app>/*","/apps/<app>"]}}
+]' --region us-west-1
+# (repeated for all 5 app rules)
+```
+
+**Resources Modified:**
+- ALB HTTPS listener rules (priorities 200, 210, 220, 230, 240) on `saleor-platform-staging-alb`
+- Region: us-west-1
+
+**Terraform Reconciliation Status:**
+- [x] Terraform code updated in `infra/terraform/modules/alb/main.tf` (same commit)
+- [ ] Terraform plan confirms no drift (run `terraform plan` to verify)
+
+**Notes:**
+The HTTP (non-HTTPS) rules already had the correct `/apps/*` paths. The mismatch was introduced when creating the HTTPS host-based rules, which incorrectly stripped the `/apps/` prefix. All 5 apps confirmed responding HTTP 200 after fix.
+
+---
+
 ### 2026-02-14 - CI/CD Pipeline Fixes (post-HTTPS migration)
 
 **Incident:** CI/CD pipeline failures after HTTPS migration
@@ -76,6 +114,32 @@ aws ecs update-service --cluster saleor-platform-staging --service storefront \
 - [x] No manual AWS infrastructure changes (only ECS task def + DB record)
 - [x] Storefront HTTPS URLs will propagate via CI/CD on next deploy
 - [ ] Terraform storefront task def still has old URLs — next `terraform apply` will fix
+
+### 2026-02-17 - Fix App Container URL Environment Variables
+
+**Incident:** Continuation of ALB routing fix — apps' `APP_API_BASE_URL` pointed to wrong subdomain
+**Responder:** Michael + PAI (Gen)
+**Time:** 2026-02-17
+
+**Root Cause:**
+App containers had `APP_API_BASE_URL=https://api.staging.michaelbean.org/apps/<app>` but apps are routed via `apps.staging.michaelbean.org`. The `api` subdomain routes to Saleor Django which returns 404 for `/apps/*` paths.
+
+**Changes Made:**
+```bash
+# Updated 5 ECS task definitions with correct APP_API_BASE_URL and APP_IFRAME_BASE_URL
+# stripe: rev 65 → 66, inventory-ops: rev 62 → 63, buylist: rev 62 → 63
+# pos: rev 62 → 63, mtg-import: rev 12 → 13
+# All updated from api.staging.michaelbean.org → apps.staging.michaelbean.org
+aws ecs register-task-definition --cli-input-json <updated-json>
+aws ecs update-service --cluster saleor-platform-staging --service <app> \
+  --task-definition <new-rev> --force-new-deployment
+```
+
+**Terraform Reconciliation Status:**
+- [x] Terraform code updated (new `public_apps_base_url` variable in same commit as ALB fix)
+- [ ] Next `terraform apply` will match the manual change
+
+---
 
 **Notes:**
 Root cause of Prisma P3009 cycle: mtg-import and inventory-ops share the same database (via symlinked schema) but have different migration directories. mtg-import's `0001_initial` tried to CREATE tables that already existed, failed, and the failed record blocked inventory-ops on subsequent runs.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -36,6 +36,10 @@ locals {
     var.public_dashboard_base_url != "" ? var.public_dashboard_base_url :
     "${local.url_scheme}://dashboard.${var.domain_name}"
   )
+
+  # Apps base URL: where Saleor apps are externally reachable
+  # Used for APP_API_BASE_URL and APP_IFRAME_BASE_URL in app containers
+  public_apps_base_url = "${local.url_scheme}://apps.${var.domain_name}"
 }
 
 # =============================================================================
@@ -217,6 +221,7 @@ module "ecs" {
   public_api_base_url        = local.public_api_base_url
   public_storefront_base_url = local.public_storefront_base_url
   public_dashboard_base_url  = local.public_dashboard_base_url
+  public_apps_base_url       = local.public_apps_base_url
 
   private_subnet_ids             = local.private_subnet_ids
   ecs_backend_security_group_id  = module.alb.ecs_backend_security_group_id
@@ -285,7 +290,7 @@ module "ecs" {
         }
       ]
       environment = {
-        STRIPE_WEBHOOK_URL       = "${local.public_api_base_url}/apps/stripe/api/webhooks/stripe"
+        STRIPE_WEBHOOK_URL       = "${local.public_apps_base_url}/apps/stripe/api/webhooks/stripe"
         APL                      = "dynamodb"
         DYNAMODB_MAIN_TABLE_NAME = module.dynamodb.stripe_app_table_name
         AWS_REGION               = var.aws_region

--- a/infra/terraform/modules/alb/main.tf
+++ b/infra/terraform/modules/alb/main.tf
@@ -471,7 +471,8 @@ resource "aws_lb_listener_rule" "dashboard" {
   }
 }
 
-# Stripe app routing: apps.{domain}/stripe/*
+# Stripe app routing: apps.{domain}/apps/stripe/*
+# Path must match the app's BASE_PATH=/apps/stripe set at Docker build time
 resource "aws_lb_listener_rule" "stripe_app" {
   count = var.enable_https ? 1 : 0
 
@@ -491,12 +492,13 @@ resource "aws_lb_listener_rule" "stripe_app" {
 
   condition {
     path_pattern {
-      values = ["/stripe/*", "/api/webhooks/stripe/*"]
+      values = ["/apps/stripe/*", "/apps/stripe"]
     }
   }
 }
 
-# Inventory ops app routing: apps.{domain}/inventory-ops/*
+# Inventory ops app routing: apps.{domain}/apps/inventory/*
+# Path must match the app's BASE_PATH=/apps/inventory set at Docker build time
 resource "aws_lb_listener_rule" "inventory_ops_app" {
   count = var.enable_https ? 1 : 0
 
@@ -516,12 +518,13 @@ resource "aws_lb_listener_rule" "inventory_ops_app" {
 
   condition {
     path_pattern {
-      values = ["/inventory-ops/*"]
+      values = ["/apps/inventory/*", "/apps/inventory"]
     }
   }
 }
 
-# Buylist app routing: apps.{domain}/buylist/*
+# Buylist app routing: apps.{domain}/apps/buylist/*
+# Path must match the app's BASE_PATH=/apps/buylist set at Docker build time
 resource "aws_lb_listener_rule" "buylist_app" {
   count = var.enable_https ? 1 : 0
 
@@ -541,12 +544,13 @@ resource "aws_lb_listener_rule" "buylist_app" {
 
   condition {
     path_pattern {
-      values = ["/buylist/*"]
+      values = ["/apps/buylist/*", "/apps/buylist"]
     }
   }
 }
 
-# POS app routing: apps.{domain}/pos/*
+# POS app routing: apps.{domain}/apps/pos/*
+# Path must match the app's BASE_PATH=/apps/pos set at Docker build time
 resource "aws_lb_listener_rule" "pos_app" {
   count = var.enable_https ? 1 : 0
 
@@ -566,12 +570,13 @@ resource "aws_lb_listener_rule" "pos_app" {
 
   condition {
     path_pattern {
-      values = ["/pos/*"]
+      values = ["/apps/pos/*", "/apps/pos"]
     }
   }
 }
 
-# MTG Import app routing: apps.{domain}/mtg-import/*
+# MTG Import app routing: apps.{domain}/apps/mtg-import/*
+# Path must match the app's BASE_PATH=/apps/mtg-import set at Docker build time
 resource "aws_lb_listener_rule" "mtg_import_app" {
   count = var.enable_https ? 1 : 0
 
@@ -591,7 +596,7 @@ resource "aws_lb_listener_rule" "mtg_import_app" {
 
   condition {
     path_pattern {
-      values = ["/mtg-import/*"]
+      values = ["/apps/mtg-import/*", "/apps/mtg-import"]
     }
   }
 }

--- a/infra/terraform/modules/ecs/main.tf
+++ b/infra/terraform/modules/ecs/main.tf
@@ -651,8 +651,8 @@ resource "aws_ecs_task_definition" "apps" {
           { name = "BASE_PATH", value = each.value.base_path },
           { name = "NEXT_PUBLIC_BASE_PATH", value = each.value.base_path },
           { name = "SALEOR_API_URL", value = "${var.public_api_base_url}/graphql/" },
-          { name = "APP_API_BASE_URL", value = "${var.public_api_base_url}${each.value.base_path}" },
-          { name = "APP_IFRAME_BASE_URL", value = "${var.public_api_base_url}${each.value.base_path}" },
+          { name = "APP_API_BASE_URL", value = "${var.public_apps_base_url}${each.value.base_path}" },
+          { name = "APP_IFRAME_BASE_URL", value = "${var.public_apps_base_url}${each.value.base_path}" },
           { name = "APP_LOG_LEVEL", value = "info" }
         ],
         # App-specific environment variables (can override APL via environment config)

--- a/infra/terraform/modules/ecs/variables.tf
+++ b/infra/terraform/modules/ecs/variables.tf
@@ -36,6 +36,11 @@ variable "public_dashboard_base_url" {
   type        = string
 }
 
+variable "public_apps_base_url" {
+  description = "Public apps base URL (e.g., https://apps.staging.michaelbean.org)"
+  type        = string
+}
+
 # Network
 variable "private_subnet_ids" {
   description = "Private subnet IDs"


### PR DESCRIPTION
## Summary
- Corrects ALB HTTPS listener routing paths for Saleor apps (inventory-ops, POS, buylist, price-sync, mtg-import)
- Updates app base URL configuration in ECS task definitions
- Logs the routing path corrections in incident-changes.md

## Files Changed
- `infra/terraform/main.tf` — base URL variable updates
- `infra/terraform/modules/alb/main.tf` — HTTPS path routing corrections
- `infra/terraform/modules/ecs/main.tf` — base URL env var passthrough
- `infra/terraform/modules/ecs/variables.tf` — new variable
- `docs/ops/incident-changes.md` — incident documentation

## Test plan
- [ ] `terraform plan` shows expected routing changes only
- [ ] Apps accessible via corrected ALB paths after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)