### PR TITLE
chore: upgrade Saleor API to 3.22.39 and Dashboard to 3.22.34

### DIFF
--- a/infra/terraform/environments/staging.tfvars
+++ b/infra/terraform/environments/staging.tfvars
@@ -109,11 +109,9 @@ apps_scaling_min_capacity = 1 # Always-on apps stay running; batch jobs (desired
 apps_scaling_max_capacity = 1 # 1 instance per app in staging
 
 # Images (pin by digest in production, use tags in staging)
-# Updated 2026-01-12: API 3.22.26, Dashboard 3.21.18
-# Note: Dashboard 3.22.9+ uses AppExtension fields (mountName, targetName, settings)
-#       that don't exist in API 3.22.x. Use Dashboard 3.21.x for compatibility.
-saleor_api_image       = "ghcr.io/saleor/saleor:3.22.26"
-saleor_dashboard_image = "ghcr.io/saleor/saleor-dashboard:3.21.18"
+# Updated 2026-03-03: API 3.22.39, Dashboard 3.22.34
+saleor_api_image       = "ghcr.io/saleor/saleor:3.22.39"
+saleor_dashboard_image = "ghcr.io/saleor/saleor-dashboard:3.22.34"
 
 # Saleor Apps image tags
 stripe_app_image_tag     = "document-polyfill-v1"


### PR DESCRIPTION
## Summary
- **API**: 3.22.26 → 3.22.39 (13 patches) — Django CVE security fixes (3.22.32), AppProblem API (3.22.36), `productBulkCreate` `trackInventory` fix (3.22.39)
- **Dashboard**: 3.21.18 → 3.22.34 (full minor bump) — bulk variant generator, product availability diagnostics, filtering improvements
- Removes outdated compatibility comment (API 3.22.39 now has `mountName`/`targetName`/`settings` AppExtension fields)

## What changed
- `infra/terraform/environments/staging.tfvars` — image tags updated, stale comment removed

## Deployment status
- Terraform applied (new task definitions registered)
- Django migrations run (exit code 0, no new migrations)
- All 4 services (api, worker, beat, dashboard) force-deployed and stable
- API health check passing

## Test plan
- [x] `terraform plan` showed only expected task definition changes + S3 CORS tightening
- [x] `terraform apply` succeeded
- [x] Django migrations completed (exit 0)
- [x] All services reached stable state
- [x] API health endpoint returns 200
- [x] API task def confirmed running `saleor:3.22.39`
- [x] Dashboard task def confirmed running `saleor-dashboard:3.22.34`
- [ ] Dashboard login and navigation (manual)
- [ ] MTG import smoke test with `trackInventory` (manual)
- [ ] POS checkout test order (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)