### PR TITLE
fix(ci): use vars.AWS_ACCOUNT_ID and fix buylist lint errors

### DIFF
--- a/.github/workflows/iam-audit.yml
+++ b/.github/workflows/iam-audit.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/saleor-platform-staging-github-actions-deploy
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/saleor-platform-staging-github-actions-deploy
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Create audit snapshot directory

--- a/.github/workflows/terraform-drift-detection.yml
+++ b/.github/workflows/terraform-drift-detection.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/saleor-platform-staging-github-actions-deploy
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/saleor-platform-staging-github-actions-deploy
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform

--- a/.github/workflows/terraform-plan-on-pr.yml
+++ b/.github/workflows/terraform-plan-on-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/saleor-platform-staging-github-actions-deploy
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/saleor-platform-staging-github-actions-deploy
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform


### PR DESCRIPTION
## Summary
- **Terraform OIDC fix**: 3 workflows (`terraform-plan-on-pr`, `terraform-drift-detection`, `iam-audit`) referenced `secrets.AWS_ACCOUNT_ID` but the value is stored as `vars.AWS_ACCOUNT_ID`. This caused every PR's Terraform Plan check to fail with "Request ARN is invalid".
- **Buylist lint fix**: 4 files had `@saleor/apps-shared` import in the internal import group instead of external, failing `simple-import-sort/imports`.

## Files changed
- `.github/workflows/terraform-plan-on-pr.yml` — `secrets` → `vars`
- `.github/workflows/terraform-drift-detection.yml` — `secrets` → `vars`
- `.github/workflows/iam-audit.yml` — `secrets` → `vars`
- `saleor-apps` submodule pointer (buylist import sort fixes)

## Test plan
- [x] Confirmed `AWS_ACCOUNT_ID` exists as repo variable (not secret)
- [x] Confirmed `deploy-staging.yml` already uses `vars.AWS_ACCOUNT_ID` successfully
- [ ] CI checks pass on this PR (chicken-and-egg: the fix IS the broken check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)