### PR TITLE
feat(storefront): add GraphQL fetch retry and request queue

### DIFF
--- a/storefront/src/lib/fetch-retry.test.ts
+++ b/storefront/src/lib/fetch-retry.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { withRetry } from "./fetch-retry";
+
+function mockResponse(status: number): Response {
+	return new Response(null, { status, statusText: `Status ${status}` });
+}
+
+describe("withRetry", () => {
+	it("returns response on success", async () => {
+		const baseFetch = vi.fn().mockResolvedValue(mockResponse(200));
+		const fetch = withRetry(baseFetch);
+
+		const response = await fetch("https://api.example.com");
+
+		expect(response.status).toBe(200);
+		expect(baseFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries on 500 and succeeds on second attempt", async () => {
+		const baseFetch = vi
+			.fn()
+			.mockResolvedValueOnce(mockResponse(500))
+			.mockResolvedValueOnce(mockResponse(200));
+
+		const fetch = withRetry(baseFetch, { baseDelay: 1 });
+		const response = await fetch("https://api.example.com");
+
+		expect(response.status).toBe(200);
+		expect(baseFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("retries on 429 (rate limit)", async () => {
+		const baseFetch = vi
+			.fn()
+			.mockResolvedValueOnce(mockResponse(429))
+			.mockResolvedValueOnce(mockResponse(200));
+
+		const fetch = withRetry(baseFetch, { baseDelay: 1 });
+		const response = await fetch("https://api.example.com");
+
+		expect(response.status).toBe(200);
+		expect(baseFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns error response after exhausting retries", async () => {
+		const baseFetch = vi.fn().mockResolvedValue(mockResponse(503));
+
+		const fetch = withRetry(baseFetch, { maxRetries: 2, baseDelay: 1 });
+		const response = await fetch("https://api.example.com");
+
+		expect(response.status).toBe(503);
+		expect(baseFetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+	});
+
+	it("retries on network error and succeeds", async () => {
+		const baseFetch = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("ECONNREFUSED"))
+			.mockResolvedValueOnce(mockResponse(200));
+
+		const fetch = withRetry(baseFetch, { baseDelay: 1 });
+		const response = await fetch("https://api.example.com");
+
+		expect(response.status).toBe(200);
+		expect(baseFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws after exhausting retries on network error", async () => {
+		const baseFetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+		const fetch = withRetry(baseFetch, { maxRetries: 1, baseDelay: 1 });
+
+		await expect(fetch("https://api.example.com")).rejects.toThrow("ECONNREFUSED");
+		expect(baseFetch).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not retry on 400 (client error)", async () => {
+		const baseFetch = vi.fn().mockResolvedValue(mockResponse(400));
+
+		const fetch = withRetry(baseFetch, { baseDelay: 1 });
+		const response = await fetch("https://api.example.com");
+
+		expect(response.status).toBe(400);
+		expect(baseFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not retry on 404", async () => {
+		const baseFetch = vi.fn().mockResolvedValue(mockResponse(404));
+
+		const fetch = withRetry(baseFetch, { baseDelay: 1 });
+		const response = await fetch("https://api.example.com");
+
+		expect(response.status).toBe(404);
+		expect(baseFetch).toHaveBeenCalledTimes(1);
+	});
+});

--- a/storefront/src/lib/fetch-retry.ts
+++ b/storefront/src/lib/fetch-retry.ts
@@ -1,0 +1,52 @@
+/**
+ * Retry wrapper for fetch requests with exponential backoff.
+ * Retries on network errors and transient server failures (408, 429, 5xx).
+ *
+ * Adapted from upstream saleor/storefront.
+ */
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
+interface RetryOptions {
+	/** Maximum number of retries (default: 2) */
+	maxRetries?: number;
+	/** Base delay in ms, doubles on each retry (default: 500) */
+	baseDelay?: number;
+}
+
+type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/** Wrap fetch with automatic retry for transient failures (network errors, 5xx). */
+export function withRetry(
+	baseFetch: FetchFn,
+	{ maxRetries = 2, baseDelay = 500 }: RetryOptions = {},
+): FetchFn {
+	return async (input, init) => {
+		let lastError: Error | null = null;
+
+		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+			try {
+				const response = await baseFetch(input, init);
+
+				if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < maxRetries) {
+					await sleep(baseDelay * Math.pow(2, attempt));
+					continue;
+				}
+
+				return response;
+			} catch (error) {
+				lastError = error instanceof Error ? error : new Error(String(error));
+
+				if (attempt < maxRetries) {
+					await sleep(baseDelay * Math.pow(2, attempt));
+					continue;
+				}
+			}
+		}
+
+		throw lastError ?? new Error("Fetch failed after retries");
+	};
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/storefront/src/lib/graphql.ts
+++ b/storefront/src/lib/graphql.ts
@@ -1,6 +1,8 @@
 import { invariant } from "ts-invariant";
 import { type TypedDocumentString } from "../gql/graphql";
 import { getServerAuthClient } from "@/app/config";
+import { withRetry } from "./fetch-retry";
+import { requestQueue } from "./request-queue";
 
 type GraphQLErrorResponse = {
 	errors: readonly {
@@ -9,6 +11,8 @@ type GraphQLErrorResponse = {
 };
 
 type GraphQLRespone<T> = { data: T } | GraphQLErrorResponse;
+
+const resilientFetch = withRetry(fetch);
 
 export async function executeGraphQL<Result, Variables>(
 	operation: TypedDocumentString<Result, Variables>,
@@ -38,9 +42,12 @@ export async function executeGraphQL<Result, Variables>(
 		next: { revalidate },
 	};
 
-	const response = withAuth
-		? await (await getServerAuthClient()).fetchWithAuth(apiUrl, input)
-		: await fetch(apiUrl, input);
+	const response = await requestQueue.enqueue(async () => {
+		if (withAuth) {
+			return (await getServerAuthClient()).fetchWithAuth(apiUrl, input);
+		}
+		return resilientFetch(apiUrl, input);
+	});
 
 	if (!response.ok) {
 		const body = await (async () => {

--- a/storefront/src/lib/request-queue.test.ts
+++ b/storefront/src/lib/request-queue.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { RequestQueue } from "./request-queue";
+
+describe("RequestQueue", () => {
+	it("executes a single request immediately", async () => {
+		const queue = new RequestQueue(3, 0);
+		const result = await queue.enqueue(() => Promise.resolve("ok"));
+		expect(result).toBe("ok");
+	});
+
+	it("limits concurrent requests to maxConcurrent", async () => {
+		const queue = new RequestQueue(2, 0);
+		let activeConcurrent = 0;
+		let maxObserved = 0;
+
+		const makeRequest = () =>
+			queue.enqueue(async () => {
+				activeConcurrent++;
+				maxObserved = Math.max(maxObserved, activeConcurrent);
+				await new Promise((r) => setTimeout(r, 50));
+				activeConcurrent--;
+				return "done";
+			});
+
+		await Promise.all([makeRequest(), makeRequest(), makeRequest(), makeRequest()]);
+
+		expect(maxObserved).toBeLessThanOrEqual(2);
+	});
+
+	it("propagates errors from enqueued functions", async () => {
+		const queue = new RequestQueue(3, 0);
+
+		await expect(
+			queue.enqueue(() => Promise.reject(new Error("boom"))),
+		).rejects.toThrow("boom");
+	});
+
+	it("continues processing after an error", async () => {
+		const queue = new RequestQueue(1, 0);
+
+		await expect(
+			queue.enqueue(() => Promise.reject(new Error("fail"))),
+		).rejects.toThrow("fail");
+
+		const result = await queue.enqueue(() => Promise.resolve("recovered"));
+		expect(result).toBe("recovered");
+	});
+
+	it("enforces minimum delay between requests", async () => {
+		const minDelay = 100;
+		const queue = new RequestQueue(3, minDelay);
+		const timestamps: number[] = [];
+
+		const makeRequest = () =>
+			queue.enqueue(async () => {
+				timestamps.push(Date.now());
+				return "done";
+			});
+
+		// Run sequentially to measure delay
+		await makeRequest();
+		await makeRequest();
+		await makeRequest();
+
+		for (let i = 1; i < timestamps.length; i++) {
+			const gap = timestamps[i] - timestamps[i - 1];
+			// Allow 20ms tolerance for timer imprecision
+			expect(gap).toBeGreaterThanOrEqual(minDelay - 20);
+		}
+	});
+});

--- a/storefront/src/lib/request-queue.test.ts
+++ b/storefront/src/lib/request-queue.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { RequestQueue } from "./request-queue";
 
 describe("RequestQueue", () => {

--- a/storefront/src/lib/request-queue.ts
+++ b/storefront/src/lib/request-queue.ts
@@ -1,0 +1,79 @@
+/**
+ * Concurrency-limited request queue with rate limiting.
+ * Prevents overwhelming the Saleor API during SSR page generation.
+ *
+ * Configurable via environment variables:
+ * - SALEOR_MAX_CONCURRENT_REQUESTS (default: 3)
+ * - SALEOR_MIN_REQUEST_DELAY_MS (default: 200)
+ *
+ * Adapted from upstream saleor/storefront.
+ */
+
+type QueueEntry = {
+	execute: () => void;
+};
+
+export class RequestQueue {
+	private queue: QueueEntry[] = [];
+	private activeCount = 0;
+	private lastRequestTime = 0;
+
+	constructor(
+		private readonly maxConcurrent: number = 3,
+		private readonly minDelayMs: number = 200,
+	) {}
+
+	async enqueue<T>(fn: () => Promise<T>): Promise<T> {
+		// Reserve slot synchronously or wait for one
+		await this.acquireSlot();
+
+		try {
+			// Enforce minimum delay between requests
+			const now = Date.now();
+			const elapsed = now - this.lastRequestTime;
+			if (elapsed < this.minDelayMs) {
+				await sleep(this.minDelayMs - elapsed);
+			}
+			this.lastRequestTime = Date.now();
+
+			return await fn();
+		} finally {
+			this.activeCount--;
+			this.processQueue();
+		}
+	}
+
+	private acquireSlot(): Promise<void> {
+		if (this.activeCount < this.maxConcurrent) {
+			// Reserve synchronously — prevents race between concurrent callers
+			this.activeCount++;
+			return Promise.resolve();
+		}
+
+		return new Promise<void>((resolve) => {
+			this.queue.push({
+				execute: () => {
+					this.activeCount++;
+					resolve();
+				},
+			});
+		});
+	}
+
+	private processQueue(): void {
+		if (this.queue.length > 0 && this.activeCount < this.maxConcurrent) {
+			const next = this.queue.shift();
+			next?.execute();
+		}
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Module-level singleton — shared across all server-side GraphQL calls
+const maxConcurrent = parseInt(process.env.SALEOR_MAX_CONCURRENT_REQUESTS || "3", 10);
+const minDelay = parseInt(process.env.SALEOR_MIN_REQUEST_DELAY_MS || "200", 10);
+
+export const requestQueue = new RequestQueue(maxConcurrent, minDelay);

--- a/storefront/src/ui/components/AuthProvider.tsx
+++ b/storefront/src/ui/components/AuthProvider.tsx
@@ -12,6 +12,7 @@ import {
 	dedupExchange,
 	fetchExchange,
 } from "urql";
+import { withRetry } from "@/lib/fetch-retry";
 
 const saleorApiUrl = process.env.NEXT_PUBLIC_SALEOR_API_URL;
 invariant(saleorApiUrl, "Missing NEXT_PUBLIC_SALEOR_API_URL env variable");
@@ -48,11 +49,15 @@ const safeFetchWithAuth = async (
 	}
 };
 
+const resilientFetchWithAuth = withRetry(
+	(input: RequestInfo | URL, init?: RequestInit) => safeFetchWithAuth(input as RequestInfo, init),
+);
+
 const makeUrqlClient = () => {
 	return createClient({
 		url: saleorApiUrl,
 		suspense: true,
-		fetch: (input, init) => safeFetchWithAuth(input as RequestInfo, init),
+		fetch: resilientFetchWithAuth,
 		exchanges: [dedupExchange, cacheExchange, fetchExchange],
 	});
 };


### PR DESCRIPTION
## Summary
- Adds `withRetry` wrapper — exponential backoff (2 retries, 500ms base) on transient failures (408, 429, 5xx, network errors)
- Adds `RequestQueue` — concurrency limiter (default 3 concurrent, 200ms min delay between requests) to prevent overwhelming the Saleor API during SSR
- Applied to both server-side `executeGraphQL` and client-side URQL client
- Configurable via `SALEOR_MAX_CONCURRENT_REQUESTS` and `SALEOR_MIN_REQUEST_DELAY_MS` env vars
- 13 new tests (8 for retry, 5 for queue) — all passing alongside existing 238 tests

Backported from upstream saleor/storefront patterns. Addresses resilience gaps identified during upstream comparison — our GraphQL client previously had zero retry, no concurrency limiting, and no timeout handling.

## Test plan
- [x] `vitest run` — 251 tests pass (14 files, 0 failures)
- [x] `next build` succeeds
- [ ] Deploy to staging and monitor for reduced 5xx errors under load
- [ ] Verify request queue rate limiting with `SALEOR_MAX_CONCURRENT_REQUESTS=1` during MTG import

🤖 Generated with [Claude Code](https://claude.com/claude-code)