### PR TITLE
feat: omnichannel customer accounts (Phases 1-4)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,7 +1,8 @@
 name: Auto-Merge on Green CI
 
 on:
-  check_suite:
+  workflow_run:
+    workflows: ["test-platform", "Codex PR Review"]
     types: [completed]
   pull_request:
     types: [labeled]
@@ -37,16 +38,22 @@ jobs:
               return;
             }
 
-            if (context.eventName === 'check_suite') {
-              // Find PRs for this head SHA targeting platform/main
-              const prs = context.payload.check_suite.pull_requests || [];
+            if (context.eventName === 'workflow_run') {
+              const run = context.payload.workflow_run;
+              if (run.conclusion !== 'success') {
+                console.log(`Workflow "${run.name}" concluded with ${run.conclusion} — skipping`);
+                return;
+              }
+
+              // workflow_run provides associated PRs
+              const prs = run.pull_requests || [];
               const targetPr = prs.find(pr => pr.base.ref === 'platform/main');
               if (!targetPr) {
-                console.log('No PR targeting platform/main in this check suite');
+                console.log('No PR targeting platform/main in this workflow run');
                 return;
               }
               core.setOutput('number', targetPr.number);
-              console.log(`PR #${targetPr.number} (check_suite)`);
+              console.log(`PR #${targetPr.number} (workflow_run: ${run.name})`);
               return;
             }
 

--- a/docs/reference/customer-accounts.md
+++ b/docs/reference/customer-accounts.md
@@ -1,0 +1,460 @@
+# Customer Accounts — Cross-Platform Analysis
+
+> **Date**: 2026-03-08
+> **Scope**: Saleor Core, Storefront, POS, Buylist, Inventory-Ops
+> **Status**: Analysis complete — no code changes
+
+## Overview
+
+This document examines how customer accounts work across every application in the platform, how they connect, and where gaps exist. The goal is to inform future work toward a unified omnichannel customer experience for the hobby gaming market.
+
+The platform uses Saleor's single `User` type as the identity foundation. POS and Buylist extend this with local state (store credit, transaction history, customer groups) stored in the shared Prisma schema. The storefront relies entirely on Saleor's GraphQL API with no local customer state.
+
+---
+
+## 1. Saleor Core — The Identity Foundation
+
+Saleor uses a **unified `User` type** for both customers and staff, distinguished by the `isStaff` boolean. There is no separate "Customer" model.
+
+### User Model — Key Fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | ID | Primary identifier across all apps |
+| `email` | String (unique) | Case-insensitive, used for login |
+| `firstName`, `lastName` | String | Display name |
+| `isActive` | Boolean | Account enabled/disabled |
+| `isStaff` | Boolean | Staff (dashboard) vs customer (storefront) |
+| `isConfirmed` | Boolean | Email confirmed after registration |
+| `languageCode` | Enum | Preferred language for notifications |
+| `externalReference` | String | External system sync ID |
+| `dateJoined` | DateTime | Account creation timestamp |
+| `lastLogin` | DateTime | Last successful authentication |
+
+### Relationships
+
+| Relationship | Type | Notes |
+|-------------|------|-------|
+| `addresses` | [Address] | Multiple per user |
+| `defaultShippingAddress` | Address | Primary shipping |
+| `defaultBillingAddress` | Address | Primary billing |
+| `orders` | OrderConnection | Full order history |
+| `checkouts` | CheckoutConnection | Active checkouts (per channel) |
+| `giftCards` | GiftCardConnection | Cards created by or assigned to user |
+| `storedPaymentMethods` | [StoredPaymentMethod] | Gateway-stored methods (Stripe, etc.) |
+
+### Metadata System
+
+Two-tier key-value metadata on every User:
+
+- **Public metadata** (`metadata`): Readable by anyone. Used by POS for `tax_exempt`, `tax_exempt_reason`, `tax_exempt_cert_id`.
+- **Private metadata** (`privateMetadata`): Staff-only. Internal notes, billing references.
+
+### Authentication
+
+| Mechanism | Details |
+|-----------|---------|
+| **JWT tokens** | `tokenCreate` (email/password) returns access + refresh tokens |
+| **Token refresh** | `tokenRefresh` with CSRF token when using cookies |
+| **Token deactivation** | `tokensDeactivateAll` invalidates all tokens |
+| **Password reset** | Email-based flow: `requestPasswordReset` → `setPassword` |
+| **Email change** | Two-step: `requestEmailChange` → `confirmEmailChange` |
+| **Account confirmation** | Registration sends confirmation email; `confirmAccount` activates |
+| **External auth (SSO)** | Plugin-based only — no native OIDC/SAML/social login |
+
+### Customer Events (Audit Trail)
+
+Saleor tracks `CustomerEvent` records for: `ACCOUNT_CREATED`, `ACCOUNT_ACTIVATED`, `ACCOUNT_DEACTIVATED`, `PASSWORD_RESET`, `EMAIL_CHANGED`, `PLACED_ORDER`, `NOTE_ADDED`, `CUSTOMER_DELETED`, and more. Requires `MANAGE_USERS` permission to view.
+
+### Address Model
+
+Phone number lives on `Address`, **not** on `User` directly. This is a recurring friction point — POS and Buylist both denormalize phone to their local transaction records.
+
+```
+Address: id, firstName, lastName, companyName, streetAddress1, streetAddress2,
+         city, cityArea, postalCode, country, countryArea, phone,
+         isDefaultShippingAddress, isDefaultBillingAddress, metadata, privateMetadata
+```
+
+### Staff Permissions & Channel Access
+
+Staff users belong to `Group` objects that grant `Permission` enums (`MANAGE_USERS`, `MANAGE_ORDERS`, etc.) and optionally restrict access to specific channels. Customers don't use groups — the `CustomerGroup` concept lives in the Prisma schema (see Inventory-Ops section).
+
+---
+
+## 2. Storefront — Minimal Account Experience
+
+The storefront uses `@saleor/auth-sdk` for authentication with tokens stored in httpOnly cookies. It has the thinnest customer feature set of any application.
+
+### Registration
+
+- **Only during checkout**: The `GuestUser` form has an optional "I want to create account" checkbox that shows a password field (8+ chars).
+- Calls `accountRegister` mutation with email, password, channel, and redirect URL.
+- No standalone registration page exists.
+
+### Login
+
+- **Login page** (`/[channel]/login`): Email/password form using `saleorAuthClient.signIn()`.
+- **Checkout login**: `SignIn` component integrated into checkout flow with "Forgot password?" link.
+- Successful login redirects to `?redirect=` parameter.
+- Token refresh is automatic via the SDK; failed refresh falls back to unauthenticated.
+
+### Token Storage
+
+```
+nextServerCookiesStorageAsync → httpOnly cookies
+  - secure: true in production (HTTPS)
+  - secure: false on localhost
+  - Both access and refresh tokens stored as cookies
+  - Auto-refresh on 401 responses
+  - CSRF protection via csrfToken
+```
+
+### Account Pages
+
+| Page | Route | Features |
+|------|-------|----------|
+| Login | `/[channel]/login` | Email/password form |
+| Order List | `/[channel]/orders` | Last 10 orders (auth required) |
+| Order Detail | `/[channel]/orders/[id]` | Line items, totals, fulfillment, addresses |
+
+**That's it.** No profile page, no address book, no password change, no account settings.
+
+### Checkout — Guest vs Registered
+
+The Contact section handles 4 states: `guestUser`, `signIn`, `signedInUser`, `resetPassword`.
+
+**Guest checkout**:
+1. Enter email only
+2. Optional "create account" checkbox + password
+3. Guest addresses entered inline — **not saved** to any account
+4. Order created without `user` field in Saleor
+
+**Registered checkout**:
+1. Login via email/password
+2. `checkoutCustomerAttach` links user to checkout
+3. Saved addresses displayed in `AddressList` from user profile
+4. Can add/edit/delete addresses during checkout (persisted to account)
+
+### Address Management
+
+Addresses are managed **only within the checkout flow**:
+- `accountAddressCreate` (with BILLING or SHIPPING type)
+- `accountAddressUpdate`
+- `accountAddressDelete`
+
+No standalone address book page exists.
+
+### GraphQL Operations Used
+
+**Queries**: `me` (user + addresses), `CurrentUser` (basic profile), `CurrentUserOrderList` (orders)
+**Mutations**: `accountRegister`, `requestPasswordReset`, `setPassword`, `accountAddressCreate/Update/Delete`, `checkoutCustomerAttach`
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `storefront/src/app/config.ts` | Auth client factory with cookie storage |
+| `storefront/src/ui/components/AuthProvider.tsx` | URQL + auth SDK provider |
+| `storefront/src/app/[channel]/(main)/login/page.tsx` | Login page |
+| `storefront/src/app/[channel]/(main)/orders/page.tsx` | Order list |
+| `storefront/src/checkout/sections/Contact/Contact.tsx` | Contact state machine |
+| `storefront/src/checkout/sections/GuestUser/` | Guest/register form |
+| `storefront/src/checkout/sections/SignIn/` | Login form in checkout |
+| `storefront/src/checkout/graphql/user.graphql` | Account GraphQL operations |
+
+---
+
+## 3. POS — Richest Customer System
+
+POS has the most complete customer management of any application. It creates Saleor User accounts, manages store credit, supports customer merge, and has infrastructure for customer groups.
+
+### Customer Creation
+
+- `customers.create` calls Saleor's `customerCreate` mutation
+- Input: email (required), firstName, lastName, optional note
+- Auto-initializes `CustomerCredit` record with $0 balance
+- Duplicate prevention: case-insensitive email check before creation
+- No password set — customer can set later via email link if they want web access
+
+### Customer Search & Attach
+
+- `customers.search`: Queries Saleor by email/name/phone (limit 10-50), enriched with store credit balances from Prisma
+- `customers.lookupByEmail`: Exact match for quick attach
+- `customers.getById`: Full detail including addresses, last 5 orders, default addresses
+- `customers.attachToTransaction`: Links customer to draft `PosTransaction`, reads tax exemption metadata, creates `CUSTOMER_ATTACHED` audit event
+- `customers.detachFromTransaction`: Reverts to guest, creates `CUSTOMER_DETACHED` audit event
+
+### Transaction Customer Data
+
+POS denormalizes customer data onto each `PosTransaction`:
+
+```
+saleorCustomerId    STRING (null = guest/walk-in)
+customerName        STRING (from Saleor)
+customerEmail       STRING (from Saleor)
+customerPhone       STRING (from address)
+isTaxExempt         BOOLEAN
+taxExemptReason     STRING
+taxExemptCertId     STRING
+```
+
+Guest transactions have `saleorCustomerId = NULL` and can still store optional name/email/phone directly.
+
+### Store Credit System
+
+The `CustomerCredit` table tracks per-customer balances:
+
+```prisma
+model CustomerCredit {
+  id                String   @id @default(uuid())
+  installationId    String
+  saleorCustomerId  String
+  balance           Decimal  @default(0)
+  currency          String   @default("USD")
+  creditTransactions CreditTransaction[]
+}
+```
+
+Transaction types: `BUYLIST_PAYOUT`, `POS_PAYMENT`, `POS_REFUND`, `ADJUSTMENT`, `EXPIRATION`
+
+Each `CreditTransaction` records: amount, balanceAfter, source (buylist or POS transaction), note, createdBy (staff), timestamp.
+
+Credit usage at POS (`customers.useCredit`):
+- Atomic serializable transaction to prevent double-spend
+- Creates `PosPayment` with STORE_CREDIT method type
+- Records `CreditTransaction` with type=POS_PAYMENT
+
+### Customer Merge
+
+`customers.merge` (source → target):
+1. Transfers credit from source to target (atomic serializable transaction)
+2. Reassigns all POS transactions from source to target
+3. Creates `CustomerMergeLog` audit record
+4. Records ADJUSTMENT credit transactions on both accounts
+
+### Customer Groups
+
+Infrastructure exists but is **not integrated with transactions**:
+
+```prisma
+model CustomerGroup {
+  id               String   @id @default(uuid())
+  installationId   String
+  name             String   // unique per installation
+  description      String?
+  color            String?
+  discountPercent  Decimal?
+  isActive         Boolean  @default(true)
+  members          CustomerGroupMember[]
+}
+```
+
+CRUD operations work, but groups don't apply automatic discounts during checkout.
+
+### Tax Exemption
+
+- Reads customer metadata: `tax_exempt`, `tax_exempt_reason`, `tax_exempt_cert_id`
+- Sets `isTaxExempt=true` on PosTransaction when attaching tax-exempt customer
+- **Cannot set** tax exemption from POS — must be set in Dashboard or via API
+
+### UI Components
+
+| Component | Purpose |
+|-----------|---------|
+| `CustomerSearch.tsx` (433 LOC) | Debounced search, results dropdown, create-new inline |
+| `pages/customers/index.tsx` (278 LOC) | Customer list with search |
+| `pages/customers/[id].tsx` (303 LOC) | Detail: contact info, credit balance, transaction history |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `pos/src/modules/customers/customers-router.ts` | 1365 LOC, 12 endpoints |
+| `pos/src/modules/customers/customers-router.test.ts` | 428 LOC tests |
+| `pos/src/modules/payments/payments-router.ts` | Order creation with customer linking |
+| `pos/src/modules/receipts/receipts-router.ts` | Receipt generation (customer name, no email for privacy) |
+
+---
+
+## 4. Buylist — Customer-Optional with Credit Integration
+
+Buylist supports both registered Saleor customers and anonymous walk-ins. Store credit payout is the primary integration point with the customer system.
+
+### Walk-In vs Registered
+
+| Feature | Walk-In | Registered |
+|---------|---------|------------|
+| Account required | No | Yes (Saleor User) |
+| Name/email/phone | Optional, stored on Buylist record | Auto-populated from Saleor |
+| Store credit payout | **Not available** (enforced) | Available |
+| Transaction history | Lost (no persistent identity) | Last 10 buylists visible |
+| Credit balance visible | N/A | Shown in search results |
+
+### Customer Association
+
+Each `Buylist` record stores:
+
+```
+saleorUserId     STRING (null for walk-ins)
+customerName     STRING (from Saleor or manual entry)
+customerEmail    STRING (from Saleor or manual entry)
+customerPhone    STRING (from Saleor address or manual entry)
+```
+
+### FOH (Front of House) Customer Flow
+
+1. **Search** for customer by email/phone/name (up to 10 results from Saleor, enriched with credit + buylist history)
+2. **Attach** existing customer, **create** new Saleor account, or **enter walk-in** details
+3. Add card items with market prices and quoted buy prices
+4. Select payout method: CASH, STORE_CREDIT, CHECK, BANK_TRANSFER, PAYPAL, OTHER
+5. If STORE_CREDIT: customer is **required** (enforced in UI)
+6. Complete via `createAndPay()` → PENDING_VERIFICATION status
+
+### BOH (Back of House) Verification
+
+1. Queue shows PENDING_VERIFICATION buylists (FIFO by paidAt)
+2. Verify card conditions (may differ from FOH entry)
+3. Adjust accepted quantities per line
+4. Update Saleor stock with condition-specific variants
+5. Create cost layer events for WAC tracking
+6. Customer info is **locked** during verification
+
+### Store Credit Payout
+
+When a buylist with STORE_CREDIT payout completes:
+- `CreditTransaction` created with type=BUYLIST_PAYOUT
+- Links back to buylist via `sourceBuylistId`
+- Balance updated atomically
+- Same `CustomerCredit` table as POS (shared Prisma schema)
+
+### Audit Trail
+
+`BuylistAuditEvent` is append-only and tracks: CREATED, CUSTOMER_ATTACHED, CUSTOMER_DETACHED, QUOTED, PAID, VERIFIED, COMPLETED, with staff attribution and state snapshots.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `buylist/src/modules/customers/customers-router.ts` | 830 LOC, customer CRUD + search |
+| `buylist/src/modules/buylists/buylists-router.ts` | 1600+ LOC, full buylist lifecycle |
+| `buylist/src/modules/boh/boh-router.ts` | 500+ LOC, verification workflow |
+| `buylist/src/ui/components/BuylistCustomerSearch.tsx` | 554 LOC, search + attach UI |
+
+---
+
+## 5. Inventory-Ops — No Customer Features
+
+Inventory-ops is purely B2B/internal: purchase orders, goods receipts, price sync, WAC calculations, cost layers.
+
+The **shared Prisma schema** (symlinked from inventory-ops to POS and Buylist) contains the customer-related models (`CustomerCredit`, `CustomerGroup`, `CustomerGroupMember`, `CustomerMergeLog`), but inventory-ops doesn't expose any customer endpoints in its tRPC router.
+
+---
+
+## 6. Cross-App Architecture
+
+### Identity Linkage
+
+```
+                    ┌─────────────────┐
+                    │   Saleor DB     │
+                    │   (User table)  │
+                    └────────┬────────┘
+                             │
+              saleorUserId   │   JWT tokens
+         ┌───────────────────┼───────────────────┐
+         │                   │                   │
+         ▼                   ▼                   ▼
+┌────────────────┐  ┌────────────────┐  ┌────────────────┐
+│   POS App      │  │  Buylist App   │  │  Storefront    │
+│                │  │                │  │                │
+│ CustomerCredit │  │ Buylist record │  │ (no local DB)  │
+│ PosTransaction │  │ CreditTxn     │  │ Pure GraphQL   │
+│ CustomerGroup  │  │ AuditEvent    │  │ client         │
+│ MergeLog       │  │                │  │                │
+└────────────────┘  └────────────────┘  └────────────────┘
+         │                   │
+         └───────┬───────────┘
+                 │
+         Shared Prisma Schema
+         (inventory-ops source)
+```
+
+**The glue is `saleorUserId`** — the Saleor User `id` stored on POS transactions, buylist records, and credit accounts.
+
+**Store credit is unified**: POS and Buylist read/write the same `CustomerCredit` table. Credit earned at the buylist counter is immediately spendable at the POS register.
+
+**The storefront is disconnected**: It talks only to Saleor's GraphQL API and has no visibility into the Prisma-side customer state (credit, groups, buylist history, POS history).
+
+### Data Flow for a Customer Lifecycle
+
+1. **Customer created** at POS counter (or Buylist, or storefront checkout) → Saleor User created
+2. **POS purchase** → `PosTransaction` with `saleorCustomerId`, draft order linked in Saleor
+3. **Buylist sell-back** → `Buylist` record with `saleorUserId`, credit issued to `CustomerCredit`
+4. **POS credit usage** → `CreditTransaction` debits balance, `PosPayment` records credit method
+5. **Online order** → Saleor order linked to same User via JWT auth
+6. **No online credit visibility** → Customer cannot see or use credit on storefront
+
+---
+
+## 7. Gap Analysis
+
+### HIGH Priority — Customer experience and revenue impact
+
+| # | Gap | Details | Affected Apps |
+|---|-----|---------|---------------|
+| 1 | **No customer profile page on storefront** | Customers cannot edit their name, email, or password from the web. Only option is to contact support or use password reset email. | Storefront |
+| 2 | **No standalone address book on storefront** | Addresses can only be managed during checkout. No way to pre-add, review, or clean up addresses outside of a purchase. | Storefront |
+| 3 | **Store credit invisible online** | Customers earn credit via POS buylist payouts and adjustments but cannot see their balance on the website. | Storefront |
+| 4 | **Store credit not usable online** | No payment method integration for store credit in storefront checkout. Would require a Saleor payment app that reads `CustomerCredit`. | Storefront, Checkout |
+| 5 | **Customer groups don't apply discounts** | `CustomerGroup` has `discountPercent` field but it's not checked during POS or Buylist transactions. Infrastructure exists, integration doesn't. | POS, Buylist |
+| 6 | **No unified customer view** | No single screen (Dashboard or otherwise) shows a customer's full cross-channel activity: online orders + POS transactions + buylist history + credit balance + group membership. | Dashboard, All |
+
+### MEDIUM Priority — Operational friction
+
+| # | Gap | Details | Affected Apps |
+|---|-----|---------|---------------|
+| 7 | **Phone number inconsistency** | Saleor stores phone on Address objects only. POS and Buylist denormalize phone to transaction records. Editing phone in Saleor doesn't update historical records. | All |
+| 8 | **No loyalty/rewards automation** | Store credit exists but isn't auto-generated from purchases (e.g., 5% back). Must be manually added by staff. | POS |
+| 9 | **Walk-in history is lost** | Walk-in POS and Buylist transactions cannot be retroactively linked to a customer account if they register later. | POS, Buylist |
+| 10 | **No SSO or social login** | Saleor's external auth is plugin-based. No Google, Apple, or social login is configured. Registration is email/password only. | Storefront |
+| 11 | **Tax exemption can't be set from POS** | POS reads tax exemption metadata but cannot write it. Staff must use Dashboard or direct API call. | POS |
+| 12 | **Buylist lacks customer merge** | POS has a full merge workflow (credit transfer + transaction reassignment + audit log). Buylist doesn't — separate router, same schema. Duplicate buylist customers must be fixed manually. | Buylist |
+
+### LOW Priority — Nice to have
+
+| # | Gap | Details | Affected Apps |
+|---|-----|---------|---------------|
+| 13 | **No wishlist/favorites** | Standard e-commerce feature. Not implemented. | Storefront |
+| 14 | **No saved payment methods page** | Stripe tokenization exists in checkout but no account page to view/manage saved cards. | Storefront |
+| 15 | **No email capture at POS basic checkout** | POS only captures email when explicitly creating or attaching a customer. Quick sales miss the opportunity. | POS |
+| 16 | **No DCI/player ID tracking** | No Magic: The Gathering-specific identifier for competitive players. Could use Saleor metadata fields but nothing is implemented. | POS, Buylist |
+
+---
+
+## 8. What's Working Well
+
+| Strength | Details |
+|----------|---------|
+| **Unified identity** | POS and Buylist create real Saleor User accounts. Same `saleorUserId` works everywhere. |
+| **Shared store credit** | Single `CustomerCredit` table in shared Prisma schema. Credit earned at buylist counter is spendable at POS register. |
+| **Customer merge (POS)** | Handles credit transfer + transaction reassignment with full audit trail and atomic transactions. |
+| **Guest support** | Both POS and Buylist handle walk-ins gracefully without forcing account creation. |
+| **Comprehensive audit trails** | Both apps log customer events (`CUSTOMER_ATTACHED`, `CUSTOMER_DETACHED`) and all credit movements with staff attribution. |
+| **Tax exemption metadata** | Clean pattern: store flags in Saleor metadata, read at POS transaction time. |
+| **Secure auth** | Storefront uses httpOnly cookies with CSRF protection. Token refresh is automatic. |
+
+---
+
+## 9. Strategic Recommendation
+
+The biggest gap is that the **storefront is disconnected from the in-store customer experience**. A customer who regularly sells cards at the buylist counter and buys at the register has a rich profile in POS/Buylist — credit balance, transaction history, group membership — but sees almost nothing when they visit the website.
+
+Closing the HIGH priority gaps (profile page, address book, credit visibility, credit as payment method) would create the unified omnichannel experience that differentiates this hobby gaming platform from a generic Saleor deployment.
+
+The recommended sequence:
+1. **Profile page + address book** (storefront) — lowest effort, highest visibility
+2. **Store credit visibility** (storefront + API) — requires a lightweight API endpoint to expose `CustomerCredit` balance for authenticated users
+3. **Customer groups → discounts** (POS/Buylist) — activate existing infrastructure
+4. **Store credit as online payment** (Saleor payment app) — most complex, highest revenue impact
+5. **Unified customer view** (Dashboard widget or custom page) — operational improvement for staff

--- a/docs/reference/omnichannel-customer-plan.md
+++ b/docs/reference/omnichannel-customer-plan.md
@@ -1,0 +1,372 @@
+# Omnichannel Customer Accounts — Implementation Plan
+
+> **Date**: 2026-03-08
+> **Status**: Plan — no code changes
+> **Prerequisite**: [Cross-Platform Analysis](customer-accounts.md) (issue #57)
+> **Tracks**: [GitHub Issue #57](https://github.com/michael-a-bean/saleor-platform/issues/57)
+
+## Executive Summary
+
+The storefront is disconnected from the rich in-store customer experience built in POS and Buylist. A customer who regularly sells cards at the buylist counter and buys at the register has credit balance, transaction history, and group membership — but sees almost nothing when they visit the website.
+
+This plan closes that gap in 5 phases, ordered by effort-to-impact ratio. Each phase delivers standalone value and can be shipped independently.
+
+### Architecture Principle
+
+**One bridge unlocks everything.** The storefront currently talks only to Saleor's GraphQL API. Store credit, customer groups, and transaction history live in the shared Prisma DB (inventory-ops schema). A single authenticated API bridge from the storefront to inventory-ops unlocks Phases 2-5. Phase 1 requires no bridge at all — it uses existing Saleor mutations.
+
+---
+
+## Phase 1: Profile Page & Address Book (Storefront)
+
+**Effort**: Small (1-2 days) | **Impact**: High visibility | **Dependencies**: None
+
+### Why First
+
+Saleor already exposes all 15 customer-facing mutations (`accountUpdate`, `passwordChange`, `requestEmailChange`, `accountAddressCreate/Update/Delete`, `accountSetDefaultAddress`, etc.). The storefront simply doesn't use them. This is pure frontend work with zero backend changes.
+
+### Technical Approach
+
+**New routes:**
+
+| Route | Purpose |
+|-------|---------|
+| `/[channel]/account` | Profile page — edit name, email, password |
+| `/[channel]/account/addresses` | Address book — list, add, edit, delete, set defaults |
+
+**Profile page (`/account`):**
+- Display: first name, last name, email (from `me` query, already used)
+- Edit name: `accountUpdate` mutation with `AccountInput { firstName, lastName }`
+- Change password: `passwordChange` mutation (requires `oldPassword` + `newPassword`)
+- Change email: Two-step — `requestEmailChange` (sends confirmation) → `confirmEmailChange` (token from email link)
+- Delete account: `accountRequestDeletion` → `accountDelete` (two-step with email confirmation)
+
+**Address book (`/account/addresses`):**
+- List: Already fetched via `me { addresses }` query
+- Add: `accountAddressCreate` with `AddressInput` + `type` (BILLING/SHIPPING)
+- Edit: `accountAddressUpdate` with address `id` + `AddressInput`
+- Delete: `accountAddressDelete` with address `id`
+- Set default: `accountSetDefaultAddress` with address `id` + `type`
+
+**Key files to modify/create:**
+
+| File | Action |
+|------|--------|
+| `storefront/src/app/[channel]/(main)/account/page.tsx` | Create — profile page |
+| `storefront/src/app/[channel]/(main)/account/addresses/page.tsx` | Create — address book |
+| `storefront/src/graphql/AccountUpdate.graphql` | Create — mutation definitions |
+| `storefront/src/ui/components/nav/components/UserMenu/` | Modify — add "My Account" link |
+| `storefront/src/checkout/sections/GuestUser/` | Modify — add "Create Account" link to standalone registration |
+
+**Registration improvement:** Currently, accounts can only be created during checkout (optional checkbox). Add a standalone `/[channel]/register` page using the existing `accountRegister` mutation.
+
+**Page-level config:** All new pages need `export const dynamic = "force-dynamic"` (auth-gated, no SSG).
+
+### What Ships
+
+A customer can log in, see their profile, edit their name, change their password, manage addresses, and set default shipping/billing addresses — all from the website. This matches the baseline of any modern e-commerce site.
+
+---
+
+## Phase 2: Store Credit Visibility (Storefront + API Bridge)
+
+**Effort**: Medium (2-3 days) | **Impact**: High differentiation | **Dependencies**: Phase 1 (account pages exist)
+
+### Why Second
+
+Credit earned in-store (via buylist payouts and POS adjustments) is invisible online. Customers call the store to check their balance. Showing the balance is a lightweight API endpoint — the complex part (earning and spending credit) already works.
+
+### Technical Approach — The API Bridge
+
+**The core problem:** Storefront authenticates via Saleor JWT. Store credit lives in inventory-ops Prisma DB. No auth path exists between them.
+
+**Solution: JWT verification middleware in inventory-ops.**
+
+```
+Storefront → inventory-ops API → Prisma DB (CustomerCredit)
+     │                │
+     └── Saleor JWT ──┘ (verify via Saleor's public key / `me` query)
+```
+
+**New inventory-ops module: `src/modules/customer-api/`**
+
+This is a public-facing REST (or tRPC) API that:
+1. Accepts Saleor JWT in `Authorization` header
+2. Verifies the token by calling Saleor's `me` query (or validates JWT signature directly)
+3. Extracts `saleorUserId` from the verified token
+4. Returns customer data scoped to that user
+
+**Endpoints:**
+
+| Endpoint | Returns |
+|----------|---------|
+| `GET /customer-api/credit/balance` | Current credit balance + currency |
+| `GET /customer-api/credit/history` | Paginated credit transactions (type, amount, date, note) |
+| `GET /customer-api/groups` | Customer's group memberships |
+
+**Security considerations:**
+- JWT verification prevents unauthorized access — only the authenticated user sees their own data
+- `installationId` scoping ensures multi-tenant isolation
+- Read-only endpoints — no credit mutations exposed to storefront
+- Rate limiting on the API bridge (100 req/min per user)
+
+**Storefront integration:**
+- New component: `StoreCreditBadge` — shows balance in account page header and UserMenu dropdown
+- New page: `/[channel]/account/credit` — full credit history with transaction table
+- API calls from Next.js server components (SSR) using the user's JWT
+
+### What Ships
+
+A customer logs into the website, sees "Store Credit: $47.50" in their account menu, and can view a history of every credit transaction (buylist payouts, POS purchases, adjustments) with dates and notes.
+
+---
+
+## Phase 3: Customer Groups → Discounts (POS + Buylist)
+
+**Effort**: Medium (2-3 days) | **Impact**: Medium — activates existing infrastructure | **Dependencies**: None (independent of Phases 1-2)
+
+### Why Third
+
+The `CustomerGroup` model already exists with `discountPercent`. CRUD operations work. Groups can be created, members added. But the discount is never applied during transactions. This is wiring, not building.
+
+### Technical Approach
+
+**POS — Apply group discount at checkout:**
+
+In `payments-router.ts`, during order creation:
+1. When customer is attached to transaction, look up their group memberships
+2. If any group has `discountPercent > 0`, apply the highest discount (not cumulative)
+3. Apply as line-item percentage discount (not Saleor voucher — avoids double-discount conflict)
+4. Display discount on receipt: "Member Discount (Gold): -10%"
+5. Record group discount in `PosTransaction` metadata for audit
+
+**Buylist — Apply group discount to buy prices:**
+
+In `buylists-router.ts`, when calculating quoted buy prices:
+1. Check customer's group membership
+2. If group has `discountPercent`, apply as premium on buy price (e.g., Gold members get 10% more for their cards)
+3. Display premium on buylist summary
+
+**Important constraint:** Group discounts are a **local concern** applied at POS/Buylist transaction time. They do NOT flow through Saleor's discount/voucher system. This prevents:
+- Double discounts (group discount + Saleor promo stacking)
+- Complex discount priority rules
+- Saleor upgrade compatibility issues
+
+**UI additions:**
+- POS checkout summary: Show "Member Discount" line when applicable
+- POS customer detail page: Show group memberships
+- Buylist FOH: Show group membership and premium rate
+
+### What Ships
+
+Staff creates customer groups (e.g., "Gold Members — 10% discount") in POS. When a Gold member checks out, their discount is automatically applied. At the buylist counter, Gold members get 10% better buy prices on their cards.
+
+---
+
+## Phase 4: Store Credit as Online Payment (Saleor Payment App)
+
+**Effort**: Large (5-8 days) | **Impact**: Highest revenue impact | **Dependencies**: Phase 2 (API bridge exists)
+
+### Why Fourth
+
+This is the most complex phase but has the highest revenue impact. Customers with credit earned in-store currently can't spend it online. Converting credit to online spending power drives web sales and closes the omnichannel loop.
+
+### Architecture Decision
+
+**Council consensus: Build in inventory-ops (Option B).**
+
+Store credit operations must execute within the same serializable transaction boundary POS already uses. A standalone payment app would need its own DB connection and duplicate concurrency logic — creating a second code path that risks double-spend. Gift card mirroring (Option C) was unanimously rejected: two sources of truth for the same balance guarantees drift.
+
+**Implementation: New module in inventory-ops with Saleor payment app webhook handlers.**
+
+If inventory-ops's app manifest can't declare payment gateway configurations, use a thin proxy app (`saleor-apps/apps/store-credit-gateway/`) that:
+1. Registers as a Saleor payment app
+2. Receives payment webhooks
+3. Delegates to inventory-ops internal API for credit operations
+4. Returns results to Saleor
+
+### Webhook Flow
+
+```
+Customer clicks "Pay with Store Credit" in checkout
+    │
+    ▼
+Storefront calls transactionInitialize(paymentGateway: "store-credit")
+    │
+    ▼
+Saleor fires TRANSACTION_INITIALIZE_SESSION webhook → inventory-ops
+    │
+    ▼
+inventory-ops webhook handler:
+  1. Extract saleorUserId from webhook payload (via sourceObject.user)
+  2. Look up CustomerCredit balance
+  3. Validate: requested amount ≤ available balance
+  4. If valid: hold credit (serializable transaction, mark as PENDING)
+  5. Return { result: CHARGE_SUCCESS, amount, pspReference: creditTxnId }
+    │
+    ▼
+Saleor marks transaction as charged → checkout can complete
+    │
+    ▼
+On TRANSACTION_CHARGE_REQUESTED (confirmation):
+  1. Finalize credit deduction (convert PENDING → COMPLETED)
+  2. Record CreditTransaction with type=ONLINE_PAYMENT, sourceOrderId
+    │
+    ▼
+On order cancellation / refund:
+  1. TRANSACTION_REFUND_REQUESTED webhook
+  2. Credit the amount back to CustomerCredit
+  3. Record CreditTransaction with type=ONLINE_REFUND
+```
+
+### Split Payment (Partial Credit + Card)
+
+Saleor supports multiple transactions per checkout. The flow:
+1. Customer applies $20 credit to a $35 order via `transactionInitialize` for store-credit gateway
+2. Remaining $15 charged to card via Stripe gateway (existing `transactionInitialize` for Stripe)
+3. Both transactions must succeed for checkout to complete
+4. If credit charge succeeds but card fails, Saleor will fire `TRANSACTION_REFUND_REQUESTED` to release the credit hold
+
+### Double-Spend Prevention
+
+The same serializable isolation level used by POS (`useCredit`) applies:
+1. `SELECT FOR UPDATE` on `CustomerCredit` row
+2. Verify `balance >= requestedAmount`
+3. Deduct and record `CreditTransaction` atomically
+4. If POS and online attempt simultaneous use, one will wait on the row lock and see the updated (lower) balance
+
+### New CreditTransaction Types
+
+Add to the `TransactionType` enum:
+- `ONLINE_PAYMENT` — credit used in storefront checkout
+- `ONLINE_REFUND` — credit returned from storefront order cancellation
+
+### Storefront Checkout UI
+
+- Add "Store Credit" payment option in checkout when balance > 0
+- Show available balance: "Store Credit: $47.50 available"
+- Allow partial application: "Apply $20.00 of store credit"
+- Show remaining balance after application
+- Remaining amount flows to card payment (Stripe)
+
+### What Ships
+
+A customer with $47.50 store credit from buylist payouts can apply it at checkout. They can use full credit or split between credit and card. Credit holds prevent double-spend across POS and online. Refunds return credit to the balance.
+
+---
+
+## Phase 5: Unified Customer View (Staff-Facing)
+
+**Effort**: Medium (3-4 days) | **Impact**: Operational improvement | **Dependencies**: Phase 2 (API bridge exists)
+
+### Why Last
+
+This is a staff tool, not customer-facing. It improves operations but doesn't directly drive revenue. It also benefits from all prior phases being in place.
+
+### Technical Approach
+
+**Option A: Dashboard Widget** — Custom Saleor Dashboard extension showing cross-channel data on the existing customer detail page. Requires Dashboard app extension API (limited).
+
+**Option B: Custom Page in POS** — Since POS already has the richest customer view (`/customers/[id]`), extend it to aggregate all channels. This is more practical because POS already has Prisma access and Saleor GraphQL access.
+
+**Recommended: Option B (extend POS customer detail page).**
+
+**Unified view sections:**
+
+| Section | Data Source | Content |
+|---------|------------|---------|
+| Profile | Saleor GraphQL | Name, email, addresses, metadata |
+| Store Credit | Prisma (CustomerCredit) | Balance, full transaction history |
+| Online Orders | Saleor GraphQL (`orders` on User) | Order list with status, totals |
+| POS Transactions | Prisma (PosTransaction) | In-store purchase history |
+| Buylist History | Prisma (Buylist) | Cards sold back, payouts |
+| Group Membership | Prisma (CustomerGroupMember) | Active groups, discount rates |
+| Merge History | Prisma (CustomerMergeLog) | Any prior account merges |
+
+**New POS endpoint:** `customers.getUnifiedView` — aggregates all data sources into a single response.
+
+### What Ships
+
+Staff at the register can pull up any customer and see everything: online orders, in-store purchases, buylist history, credit balance, group membership, and merge history — all on one screen.
+
+---
+
+## Cross-Cutting Concerns
+
+### Phone Number Consistency (Gap #7)
+
+**Current state:** Saleor stores phone on `Address`, not `User`. POS and Buylist denormalize phone to transaction records at attach time. Editing the address phone doesn't update historical records.
+
+**Recommendation:** Accept this as intentional denormalization. Transaction records should snapshot the phone at transaction time (audit correctness). Add a `phone` field to the customer search/display that reads from the default address. Don't attempt to sync phone across historical records — that's not a bug, it's an audit feature.
+
+### Walk-In Transaction Linking (Gap #9)
+
+**Current state:** Walk-in POS and Buylist transactions have `saleorCustomerId = NULL`. They can't be retroactively linked if the customer registers later.
+
+**Recommendation:** Add a "Claim Transactions" endpoint to POS:
+1. Staff searches for walk-in transactions by date range, name, or email fragment
+2. Staff selects matching transactions
+3. System sets `saleorCustomerId` on selected transactions
+4. Creates audit event: `WALK_IN_CLAIMED`
+5. Does NOT move credit — walk-in transactions didn't earn credit (credit requires a customer account at payout time)
+
+**Effort:** Small (< 1 day). Can be done independently at any time.
+
+### Buylist Customer Merge (Gap #12)
+
+**Recommendation:** Port the existing POS merge logic to Buylist. The `customers.merge` endpoint in POS already handles credit transfer + transaction reassignment + audit logging. Buylist needs an equivalent that also reassigns `Buylist` records. Since both share the same Prisma schema, the credit transfer logic is identical — only the transaction reassignment differs (Buylist records vs POS transactions).
+
+**Effort:** Small (< 1 day). The pattern is proven in POS.
+
+---
+
+## Sequencing & Dependencies
+
+```
+Phase 1 ──────────────────────────────► Ships independently
+(Profile + Addresses)                   Pure storefront, no backend
+
+Phase 2 ──────────────────────────────► Ships independently
+(Credit Visibility)                     Requires API bridge (new)
+     │
+     ▼
+Phase 4 ──────────────────────────────► Depends on Phase 2
+(Credit as Payment)                     Uses same API bridge + payment app
+
+Phase 3 ──────────────────────────────► Ships independently
+(Group Discounts)                       POS/Buylist only, no storefront
+
+Phase 5 ──────────────────────────────► Benefits from all prior phases
+(Unified View)                          Aggregates data from all sources
+```
+
+**Critical path:** Phase 2 → Phase 4 (API bridge must exist before payment app can use it).
+
+**Parallel tracks:** Phases 1 and 3 can be developed simultaneously and independently.
+
+## Effort Summary
+
+| Phase | Effort | Team | Parallel? |
+|-------|--------|------|-----------|
+| 1. Profile + Addresses | 1-2 days | Storefront | Yes — independent |
+| 2. Credit Visibility | 2-3 days | Storefront + inventory-ops | Yes — independent |
+| 3. Group Discounts | 2-3 days | POS + Buylist | Yes — independent |
+| 4. Credit Payment | 5-8 days | inventory-ops + Storefront | After Phase 2 |
+| 5. Unified View | 3-4 days | POS | After Phase 2 |
+| Walk-in Linking | < 1 day | POS | Anytime |
+| Buylist Merge | < 1 day | Buylist | Anytime |
+| **Total** | **~15-22 days** | | |
+
+## What's Explicitly Out of Scope
+
+- SSO / social login (Gap #10) — requires Saleor auth plugin, low ROI for hobby gaming
+- Wishlist / favorites (Gap #13) — nice-to-have, not omnichannel
+- Saved payment methods page (Gap #14) — Stripe handles this
+- DCI/player ID tracking (Gap #16) — future Saleor metadata usage
+- Loyalty/rewards automation (Gap #8) — requires business rules definition before implementation
+- Tax exemption from POS (Gap #11) — requires Saleor metadata write, small but separate concern
+- Email capture at POS basic checkout (Gap #15) — UX decision, not architecture
+
+## Anti-Constraint Validation
+
+This entire plan extends Saleor via apps, webhooks, and API configuration. **No Saleor core modifications are required.** All customer-facing mutations already exist in Saleor's GraphQL API. The payment app uses Saleor's standard webhook contract. The API bridge is a new module in an existing Saleor app (inventory-ops).

--- a/docs/reference/omnichannel-customer-plan.md
+++ b/docs/reference/omnichannel-customer-plan.md
@@ -115,6 +115,10 @@ This is a public-facing REST (or tRPC) API that:
 - New page: `/[channel]/account/credit` — full credit history with transaction table
 - API calls from Next.js server components (SSR) using the user's JWT
 
+### Phase 1 Cleanup (bundled with Phase 2)
+
+- Fix `countryStr in CountryCode` enum validation — checks keys instead of values, silently coerces non-US countries to `"US"`. Use `Object.values(CountryCode).includes()` instead.
+
 ### What Ships
 
 A customer logs into the website, sees "Store Credit: $47.50" in their account menu, and can view a history of every credit transaction (buylist payouts, POS purchases, adjustments) with dates and notes.

--- a/docs/reference/pr-review-pipeline.md
+++ b/docs/reference/pr-review-pipeline.md
@@ -87,3 +87,6 @@ It shouldn't — the skill only handles CI failures. If this happens, verify you
 
 ### Stale REQUEST_CHANGES blocking merge after fix
 Push a new commit. The `synchronize` event triggers a new Codex review, which dismisses the previous REQUEST_CHANGES before submitting a fresh review.
+
+### Auto-merge not firing after CI passes
+The auto-merge workflow uses `workflow_run` (not `check_suite`) to listen for `test-platform` and `Codex PR Review` completion. `check_suite` events from `GITHUB_TOKEN` don't trigger other workflows due to GitHub's anti-cascade protection — this is why `workflow_run` is required.

--- a/storefront/src/app/[channel]/(main)/account/actions.ts
+++ b/storefront/src/app/[channel]/(main)/account/actions.ts
@@ -1,0 +1,151 @@
+"use server";
+
+import { executeGraphQL } from "@/lib/graphql";
+import {
+	AccountUpdateDocument,
+	PasswordChangeDocument,
+	AccountSetDefaultAddressDocument,
+	AccountAddressDeleteDocument,
+	AccountAddressCreateDocument,
+	AccountAddressUpdateDocument,
+	CountryCode,
+	type AddressTypeEnum,
+} from "@/gql/graphql";
+import { redirect } from "next/navigation";
+
+export async function updateProfile(channelSlug: string, formData: FormData) {
+	const firstName = formData.get("firstName")?.toString() ?? "";
+	const lastName = formData.get("lastName")?.toString() ?? "";
+
+	const { accountUpdate } = await executeGraphQL(AccountUpdateDocument, {
+		variables: { input: { firstName, lastName } },
+		cache: "no-cache",
+	});
+
+	const errors = accountUpdate?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account?status=profile_error`);
+	}
+
+	redirect(`/${channelSlug}/account?status=profile_updated`);
+}
+
+export async function changePassword(channelSlug: string, formData: FormData) {
+	const oldPassword = formData.get("oldPassword")?.toString() ?? "";
+	const newPassword = formData.get("newPassword")?.toString() ?? "";
+	const confirmPassword = formData.get("confirmPassword")?.toString() ?? "";
+
+	if (!oldPassword) {
+		redirect(`/${channelSlug}/account?status=password_required`);
+	}
+
+	if (newPassword !== confirmPassword) {
+		redirect(`/${channelSlug}/account?status=passwords_mismatch`);
+	}
+
+	if (newPassword.length < 8) {
+		redirect(`/${channelSlug}/account?status=password_too_short`);
+	}
+
+	const { passwordChange } = await executeGraphQL(PasswordChangeDocument, {
+		variables: { newPassword, oldPassword },
+		cache: "no-cache",
+	});
+
+	const errors = passwordChange?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account?status=password_error`);
+	}
+
+	redirect(`/${channelSlug}/account?status=password_changed`);
+}
+
+export async function deleteAddress(channelSlug: string, addressId: string) {
+	if (!addressId || addressId.length > 256) {
+		redirect(`/${channelSlug}/account/addresses?status=invalid_address`);
+	}
+
+	const { accountAddressDelete } = await executeGraphQL(AccountAddressDeleteDocument, {
+		variables: { id: addressId },
+		cache: "no-cache",
+	});
+
+	const errors = accountAddressDelete?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account/addresses?status=delete_error`);
+	}
+
+	redirect(`/${channelSlug}/account/addresses?status=address_deleted`);
+}
+
+export async function setDefaultAddress(channelSlug: string, addressId: string, type: AddressTypeEnum) {
+	if (!addressId || addressId.length > 256) {
+		redirect(`/${channelSlug}/account/addresses?status=invalid_address`);
+	}
+
+	const { accountSetDefaultAddress } = await executeGraphQL(AccountSetDefaultAddressDocument, {
+		variables: { id: addressId, type },
+		cache: "no-cache",
+	});
+
+	const errors = accountSetDefaultAddress?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account/addresses?status=default_error`);
+	}
+
+	redirect(`/${channelSlug}/account/addresses?status=default_updated`);
+}
+
+export async function createAddress(channelSlug: string, formData: FormData) {
+	const address = extractAddressFromForm(formData);
+
+	const { accountAddressCreate } = await executeGraphQL(AccountAddressCreateDocument, {
+		variables: { address },
+		cache: "no-cache",
+	});
+
+	const errors = accountAddressCreate?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account/addresses?status=create_error`);
+	}
+
+	redirect(`/${channelSlug}/account/addresses?status=address_added`);
+}
+
+export async function updateAddress(channelSlug: string, addressId: string, formData: FormData) {
+	if (!addressId || addressId.length > 256) {
+		redirect(`/${channelSlug}/account/addresses?status=invalid_address`);
+	}
+
+	const address = extractAddressFromForm(formData);
+
+	const { accountAddressUpdate } = await executeGraphQL(AccountAddressUpdateDocument, {
+		variables: { id: addressId, address },
+		cache: "no-cache",
+	});
+
+	const errors = accountAddressUpdate?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account/addresses?status=update_error`);
+	}
+
+	redirect(`/${channelSlug}/account/addresses?status=address_updated`);
+}
+
+function extractAddressFromForm(formData: FormData) {
+	const countryStr = formData.get("country")?.toString() ?? "US";
+	const country = (countryStr in CountryCode ? countryStr : "US") as CountryCode;
+
+	return {
+		firstName: formData.get("firstName")?.toString() ?? "",
+		lastName: formData.get("lastName")?.toString() ?? "",
+		companyName: formData.get("companyName")?.toString() ?? "",
+		streetAddress1: formData.get("streetAddress1")?.toString() ?? "",
+		streetAddress2: formData.get("streetAddress2")?.toString() ?? "",
+		city: formData.get("city")?.toString() ?? "",
+		postalCode: formData.get("postalCode")?.toString() ?? "",
+		countryArea: formData.get("countryArea")?.toString() ?? "",
+		country,
+		phone: formData.get("phone")?.toString() ?? "",
+	};
+}

--- a/storefront/src/app/[channel]/(main)/account/actions.ts
+++ b/storefront/src/app/[channel]/(main)/account/actions.ts
@@ -134,7 +134,7 @@ export async function updateAddress(channelSlug: string, addressId: string, form
 
 function extractAddressFromForm(formData: FormData) {
 	const countryStr = formData.get("country")?.toString() ?? "US";
-	const country = (countryStr in CountryCode ? countryStr : "US") as CountryCode;
+	const country = (Object.values(CountryCode).includes(countryStr as CountryCode) ? countryStr : "US") as CountryCode;
 
 	return {
 		firstName: formData.get("firstName")?.toString() ?? "",

--- a/storefront/src/app/[channel]/(main)/account/addresses/AddressCard.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/AddressCard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
+import { deleteAddress, setDefaultAddress } from "../actions";
+import { AddressTypeEnum } from "@/gql/graphql";
+import type { AccountAddress } from "./types";
+
+type Props = {
+	address: AccountAddress;
+	channelSlug: string;
+	isDefaultShipping: boolean;
+	isDefaultBilling: boolean;
+};
+
+export function AddressCard({ address, channelSlug, isDefaultShipping, isDefaultBilling }: Props) {
+	return (
+		<div className="rounded-lg border bg-white p-4">
+			<div className="mb-2 flex flex-wrap gap-1">
+				{isDefaultShipping && (
+					<span className="inline-flex rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+						Default Shipping
+					</span>
+				)}
+				{isDefaultBilling && (
+					<span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800">
+						Default Billing
+					</span>
+				)}
+			</div>
+
+			<p className="font-medium text-neutral-900">
+				{address.firstName} {address.lastName}
+			</p>
+			{address.companyName && <p className="text-sm text-neutral-600">{address.companyName}</p>}
+			<p className="text-sm text-neutral-600">{address.streetAddress1}</p>
+			{address.streetAddress2 && (
+				<p className="text-sm text-neutral-600">{address.streetAddress2}</p>
+			)}
+			<p className="text-sm text-neutral-600">
+				{address.city}
+				{address.countryArea ? `, ${address.countryArea}` : ""} {address.postalCode}
+			</p>
+			<p className="text-sm text-neutral-600">{address.country.country}</p>
+			{address.phone && <p className="mt-1 text-sm text-neutral-500">{address.phone}</p>}
+
+			<div className="mt-4 flex flex-wrap gap-2">
+				<LinkWithChannel
+					href={`/account/addresses?edit=${address.id}`}
+					className="text-xs font-medium text-neutral-600 hover:text-neutral-900"
+				>
+					Edit
+				</LinkWithChannel>
+				{!isDefaultShipping && (
+					<button
+						onClick={() => setDefaultAddress(channelSlug, address.id, AddressTypeEnum.Shipping)}
+						className="text-xs font-medium text-neutral-600 hover:text-neutral-900"
+					>
+						Set as Shipping
+					</button>
+				)}
+				{!isDefaultBilling && (
+					<button
+						onClick={() => setDefaultAddress(channelSlug, address.id, AddressTypeEnum.Billing)}
+						className="text-xs font-medium text-neutral-600 hover:text-neutral-900"
+					>
+						Set as Billing
+					</button>
+				)}
+				<button
+					onClick={() => {
+						if (confirm("Delete this address?")) {
+							deleteAddress(channelSlug, address.id);
+						}
+					}}
+					className="text-xs font-medium text-red-600 hover:text-red-800"
+				>
+					Delete
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/account/addresses/AddressForm.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/AddressForm.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
+import { createAddress, updateAddress } from "../actions";
+import type { AccountAddress } from "./types";
+
+type Props = {
+	channelSlug: string;
+	address?: AccountAddress;
+};
+
+export function AddressForm({ channelSlug, address }: Props) {
+	const isEditing = !!address;
+
+	const handleSubmit = async (formData: FormData) => {
+		if (isEditing) {
+			await updateAddress(channelSlug, address.id, formData);
+		} else {
+			await createAddress(channelSlug, formData);
+		}
+	};
+
+	return (
+		<form action={handleSubmit}>
+			<div className="grid gap-4 sm:grid-cols-2">
+				<div>
+					<label htmlFor="firstName" className="block text-sm font-medium text-neutral-700">
+						First Name
+					</label>
+					<input
+						id="firstName"
+						name="firstName"
+						type="text"
+						required
+						defaultValue={address?.firstName ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div>
+					<label htmlFor="lastName" className="block text-sm font-medium text-neutral-700">
+						Last Name
+					</label>
+					<input
+						id="lastName"
+						name="lastName"
+						type="text"
+						required
+						defaultValue={address?.lastName ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div className="sm:col-span-2">
+					<label htmlFor="companyName" className="block text-sm font-medium text-neutral-700">
+						Company
+					</label>
+					<input
+						id="companyName"
+						name="companyName"
+						type="text"
+						defaultValue={address?.companyName ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div className="sm:col-span-2">
+					<label htmlFor="streetAddress1" className="block text-sm font-medium text-neutral-700">
+						Street Address
+					</label>
+					<input
+						id="streetAddress1"
+						name="streetAddress1"
+						type="text"
+						required
+						defaultValue={address?.streetAddress1 ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div className="sm:col-span-2">
+					<label htmlFor="streetAddress2" className="block text-sm font-medium text-neutral-700">
+						Apt, Suite, etc.
+					</label>
+					<input
+						id="streetAddress2"
+						name="streetAddress2"
+						type="text"
+						defaultValue={address?.streetAddress2 ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div>
+					<label htmlFor="city" className="block text-sm font-medium text-neutral-700">
+						City
+					</label>
+					<input
+						id="city"
+						name="city"
+						type="text"
+						required
+						defaultValue={address?.city ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div>
+					<label htmlFor="countryArea" className="block text-sm font-medium text-neutral-700">
+						State / Province
+					</label>
+					<input
+						id="countryArea"
+						name="countryArea"
+						type="text"
+						defaultValue={address?.countryArea ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div>
+					<label htmlFor="postalCode" className="block text-sm font-medium text-neutral-700">
+						Postal Code
+					</label>
+					<input
+						id="postalCode"
+						name="postalCode"
+						type="text"
+						required
+						defaultValue={address?.postalCode ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+				<div>
+					<label htmlFor="country" className="block text-sm font-medium text-neutral-700">
+						Country
+					</label>
+					<select
+						id="country"
+						name="country"
+						defaultValue={address?.country.code ?? "US"}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					>
+						<option value="US">United States</option>
+						<option value="CA">Canada</option>
+					</select>
+				</div>
+				<div className="sm:col-span-2">
+					<label htmlFor="phone" className="block text-sm font-medium text-neutral-700">
+						Phone
+					</label>
+					<input
+						id="phone"
+						name="phone"
+						type="tel"
+						defaultValue={address?.phone ?? ""}
+						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+					/>
+				</div>
+			</div>
+			<div className="mt-6 flex gap-2">
+				<button
+					type="submit"
+					className="rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+				>
+					{isEditing ? "Update Address" : "Add Address"}
+				</button>
+				<LinkWithChannel
+					href="/account/addresses"
+					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+				>
+					Cancel
+				</LinkWithChannel>
+			</div>
+		</form>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/account/addresses/AddressForm.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/AddressForm.tsx
@@ -2,6 +2,7 @@
 
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
 import { createAddress, updateAddress } from "../actions";
+import { inputClassName, labelClassName } from "../styles";
 import type { AccountAddress } from "./types";
 
 type Props = {
@@ -24,7 +25,7 @@ export function AddressForm({ channelSlug, address }: Props) {
 		<form action={handleSubmit}>
 			<div className="grid gap-4 sm:grid-cols-2">
 				<div>
-					<label htmlFor="firstName" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="firstName" className={labelClassName}>
 						First Name
 					</label>
 					<input
@@ -33,11 +34,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						type="text"
 						required
 						defaultValue={address?.firstName ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div>
-					<label htmlFor="lastName" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="lastName" className={labelClassName}>
 						Last Name
 					</label>
 					<input
@@ -46,11 +47,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						type="text"
 						required
 						defaultValue={address?.lastName ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div className="sm:col-span-2">
-					<label htmlFor="companyName" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="companyName" className={labelClassName}>
 						Company
 					</label>
 					<input
@@ -58,11 +59,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						name="companyName"
 						type="text"
 						defaultValue={address?.companyName ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div className="sm:col-span-2">
-					<label htmlFor="streetAddress1" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="streetAddress1" className={labelClassName}>
 						Street Address
 					</label>
 					<input
@@ -71,11 +72,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						type="text"
 						required
 						defaultValue={address?.streetAddress1 ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div className="sm:col-span-2">
-					<label htmlFor="streetAddress2" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="streetAddress2" className={labelClassName}>
 						Apt, Suite, etc.
 					</label>
 					<input
@@ -83,11 +84,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						name="streetAddress2"
 						type="text"
 						defaultValue={address?.streetAddress2 ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div>
-					<label htmlFor="city" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="city" className={labelClassName}>
 						City
 					</label>
 					<input
@@ -96,11 +97,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						type="text"
 						required
 						defaultValue={address?.city ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div>
-					<label htmlFor="countryArea" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="countryArea" className={labelClassName}>
 						State / Province
 					</label>
 					<input
@@ -108,11 +109,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						name="countryArea"
 						type="text"
 						defaultValue={address?.countryArea ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div>
-					<label htmlFor="postalCode" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="postalCode" className={labelClassName}>
 						Postal Code
 					</label>
 					<input
@@ -121,25 +122,25 @@ export function AddressForm({ channelSlug, address }: Props) {
 						type="text"
 						required
 						defaultValue={address?.postalCode ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 				<div>
-					<label htmlFor="country" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="country" className={labelClassName}>
 						Country
 					</label>
 					<select
 						id="country"
 						name="country"
 						defaultValue={address?.country.code ?? "US"}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					>
 						<option value="US">United States</option>
 						<option value="CA">Canada</option>
 					</select>
 				</div>
 				<div className="sm:col-span-2">
-					<label htmlFor="phone" className="block text-sm font-medium text-neutral-700">
+					<label htmlFor="phone" className={labelClassName}>
 						Phone
 					</label>
 					<input
@@ -147,7 +148,7 @@ export function AddressForm({ channelSlug, address }: Props) {
 						name="phone"
 						type="tel"
 						defaultValue={address?.phone ?? ""}
-						className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+						className={inputClassName}
 					/>
 				</div>
 			</div>

--- a/storefront/src/app/[channel]/(main)/account/addresses/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/page.tsx
@@ -1,0 +1,107 @@
+import { MeWithAddressesDocument } from "@/gql/graphql";
+import { executeGraphQL } from "@/lib/graphql";
+import { LoginForm } from "@/ui/components/LoginForm";
+import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
+import { AddressCard } from "./AddressCard";
+import { AddressForm } from "./AddressForm";
+import { getAddressMessage } from "../messages";
+
+export const dynamic = "force-dynamic";
+
+export default async function AddressesPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ channel: string }>;
+	searchParams: Promise<{ status?: string; add?: string; edit?: string }>;
+}) {
+	const { channel } = await params;
+	const { status, add, edit } = await searchParams;
+
+	const { me: user } = await executeGraphQL(MeWithAddressesDocument, {
+		cache: "no-cache",
+	});
+
+	if (!user) {
+		return <LoginForm />;
+	}
+
+	const addresses = user.addresses ?? [];
+	const defaultShippingId = user.defaultShippingAddress?.id;
+	const defaultBillingId = user.defaultBillingAddress?.id;
+	const editingAddress = edit ? addresses.find((a) => a.id === edit) : null;
+	const message = getAddressMessage(status);
+
+	return (
+		<div className="mx-auto max-w-7xl p-8">
+			<div className="flex items-center justify-between">
+				<h1 className="text-2xl font-bold tracking-tight text-neutral-900">Addresses</h1>
+				<LinkWithChannel
+					href="/account"
+					className="text-sm font-medium text-neutral-500 hover:text-neutral-700"
+				>
+					Back to Account
+				</LinkWithChannel>
+			</div>
+
+			{message && (
+				<div
+					className={`mt-4 rounded-md p-4 text-sm ${
+						message.type === "success"
+							? "bg-green-50 text-green-800"
+							: "bg-red-50 text-red-800"
+					}`}
+				>
+					{message.text}
+				</div>
+			)}
+
+			{/* Add/Edit Form */}
+			{(add !== undefined || editingAddress) && (
+				<div className="mt-6 rounded-lg border bg-white p-6">
+					<h2 className="mb-4 text-lg font-semibold text-neutral-900">
+						{editingAddress ? "Edit Address" : "Add New Address"}
+					</h2>
+					<AddressForm channelSlug={channel} address={editingAddress ?? undefined} />
+				</div>
+			)}
+
+			{/* Address List */}
+			{addresses.length === 0 ? (
+				<div className="mt-8 rounded border border-neutral-100 bg-white p-8 text-center">
+					<p className="text-neutral-500">No addresses saved yet.</p>
+					<LinkWithChannel
+						href="/account/addresses?add"
+						className="mt-4 inline-block rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+					>
+						Add Address
+					</LinkWithChannel>
+				</div>
+			) : (
+				<>
+					<div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{addresses.map((address) => (
+							<AddressCard
+								key={address.id}
+								address={address}
+								channelSlug={channel}
+								isDefaultShipping={address.id === defaultShippingId}
+								isDefaultBilling={address.id === defaultBillingId}
+							/>
+						))}
+					</div>
+					{add === undefined && !editingAddress && (
+						<div className="mt-6">
+							<LinkWithChannel
+								href="/account/addresses?add"
+								className="rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+							>
+								Add Address
+							</LinkWithChannel>
+						</div>
+					)}
+				</>
+			)}
+		</div>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/account/addresses/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/page.tsx
@@ -1,6 +1,7 @@
 import { MeWithAddressesDocument } from "@/gql/graphql";
 import { executeGraphQL } from "@/lib/graphql";
 import { LoginForm } from "@/ui/components/LoginForm";
+import { StatusBanner } from "@/ui/components/StatusBanner";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
 import { AddressCard } from "./AddressCard";
 import { AddressForm } from "./AddressForm";
@@ -44,17 +45,7 @@ export default async function AddressesPage({
 				</LinkWithChannel>
 			</div>
 
-			{message && (
-				<div
-					className={`mt-4 rounded-md p-4 text-sm ${
-						message.type === "success"
-							? "bg-green-50 text-green-800"
-							: "bg-red-50 text-red-800"
-					}`}
-				>
-					{message.text}
-				</div>
-			)}
+			<StatusBanner message={message} />
 
 			{/* Add/Edit Form */}
 			{(add !== undefined || editingAddress) && (

--- a/storefront/src/app/[channel]/(main)/account/addresses/types.ts
+++ b/storefront/src/app/[channel]/(main)/account/addresses/types.ts
@@ -1,0 +1,13 @@
+export type AccountAddress = {
+	id: string;
+	firstName: string;
+	lastName: string;
+	companyName: string;
+	streetAddress1: string;
+	streetAddress2: string;
+	city: string;
+	postalCode: string;
+	countryArea: string;
+	country: { country: string; code: string };
+	phone?: string | null;
+};

--- a/storefront/src/app/[channel]/(main)/account/addresses/types.ts
+++ b/storefront/src/app/[channel]/(main)/account/addresses/types.ts
@@ -1,13 +1,3 @@
-export type AccountAddress = {
-	id: string;
-	firstName: string;
-	lastName: string;
-	companyName: string;
-	streetAddress1: string;
-	streetAddress2: string;
-	city: string;
-	postalCode: string;
-	countryArea: string;
-	country: { country: string; code: string };
-	phone?: string | null;
-};
+import type { MeWithAddressesQuery } from "@/gql/graphql";
+
+export type AccountAddress = NonNullable<MeWithAddressesQuery["me"]>["addresses"][number];

--- a/storefront/src/app/[channel]/(main)/account/credit/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/credit/page.tsx
@@ -1,0 +1,175 @@
+import { CurrentUserDocument } from "@/gql/graphql";
+import { executeGraphQL } from "@/lib/graphql";
+import { getStoreCredit, getCreditHistory } from "@/lib/customer-api";
+import { formatMoney } from "@/lib/utils";
+import { LoginForm } from "@/ui/components/LoginForm";
+import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
+
+export const dynamic = "force-dynamic";
+
+function formatTransactionType(type: string): string {
+	return type
+		.replace(/_/g, " ")
+		.toLowerCase()
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatDate(dateString: string): string {
+	return new Date(dateString).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+export default async function StoreCreditPage() {
+	const { me: user } = await executeGraphQL(CurrentUserDocument, {
+		cache: "no-cache",
+	});
+
+	if (!user) {
+		return <LoginForm />;
+	}
+
+	const [credit, history] = await Promise.all([getStoreCredit(), getCreditHistory()]);
+
+	const balance = credit?.balance ?? 0;
+	const currency = credit?.currency ?? "USD";
+	const transactions = history?.transactions ?? [];
+
+	return (
+		<div className="mx-auto max-w-7xl p-8">
+			<div className="flex items-center justify-between">
+				<h1 className="text-2xl font-bold tracking-tight text-neutral-900">Store Credit</h1>
+				<LinkWithChannel
+					href="/account"
+					className="text-sm font-medium text-neutral-500 hover:text-neutral-700"
+				>
+					Back to Account
+				</LinkWithChannel>
+			</div>
+
+			{/* Balance Card */}
+			<div className="mt-8 rounded-lg border bg-white p-6">
+				<p className="text-sm font-medium text-neutral-500">Current Balance</p>
+				<p className="mt-2 text-4xl font-bold tracking-tight text-neutral-900">
+					{formatMoney(balance, currency)}
+				</p>
+				{balance > 0 && (
+					<p className="mt-1 text-sm text-green-600">
+						Available to use on your next purchase
+					</p>
+				)}
+			</div>
+
+			{/* Transaction History */}
+			<div className="mt-8 rounded-lg border bg-white">
+				<div className="border-b px-6 py-4">
+					<h2 className="text-lg font-semibold text-neutral-900">Transaction History</h2>
+				</div>
+
+				{transactions.length === 0 ? (
+					<div className="px-6 py-12 text-center">
+						<p className="text-sm text-neutral-500">No transactions yet.</p>
+						<p className="mt-1 text-sm text-neutral-400">
+							Store credit from buylists and returns will appear here.
+						</p>
+					</div>
+				) : (
+					<>
+						{/* Desktop Table */}
+						<div className="hidden md:block">
+							<table className="w-full">
+								<thead>
+									<tr className="border-b text-left text-sm font-medium text-neutral-500">
+										<th className="px-6 py-3">Date</th>
+										<th className="px-6 py-3">Type</th>
+										<th className="px-6 py-3 text-right">Amount</th>
+										<th className="px-6 py-3 text-right">Balance After</th>
+										<th className="px-6 py-3">Note</th>
+									</tr>
+								</thead>
+								<tbody className="divide-y">
+									{transactions.map((tx) => (
+										<tr key={tx.id} className="text-sm">
+											<td className="px-6 py-3 text-neutral-600">
+												{formatDate(tx.createdAt)}
+											</td>
+											<td className="px-6 py-3 text-neutral-900">
+												{formatTransactionType(tx.type)}
+											</td>
+											<td
+												className={`px-6 py-3 text-right font-medium ${
+													tx.amount >= 0 ? "text-green-600" : "text-red-600"
+												}`}
+											>
+												{tx.amount >= 0 ? "+" : ""}
+												{formatMoney(Math.abs(tx.amount), currency)}
+											</td>
+											<td className="px-6 py-3 text-right text-neutral-600">
+												{formatMoney(tx.balanceAfter, currency)}
+											</td>
+											<td className="px-6 py-3 text-neutral-500">
+												{tx.note ?? "-"}
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+
+						{/* Mobile Cards */}
+						<div className="divide-y md:hidden">
+							{transactions.map((tx) => (
+								<div key={tx.id} className="px-6 py-4">
+									<div className="flex items-center justify-between">
+										<span className="text-sm font-medium text-neutral-900">
+											{formatTransactionType(tx.type)}
+										</span>
+										<span
+											className={`text-sm font-medium ${
+												tx.amount >= 0 ? "text-green-600" : "text-red-600"
+											}`}
+										>
+											{tx.amount >= 0 ? "+" : ""}
+											{formatMoney(Math.abs(tx.amount), currency)}
+										</span>
+									</div>
+									<div className="mt-1 flex items-center justify-between">
+										<span className="text-xs text-neutral-500">
+											{formatDate(tx.createdAt)}
+										</span>
+										<span className="text-xs text-neutral-500">
+											Balance: {formatMoney(tx.balanceAfter, currency)}
+										</span>
+									</div>
+									{tx.note && (
+										<p className="mt-1 text-xs text-neutral-400">{tx.note}</p>
+									)}
+								</div>
+							))}
+						</div>
+					</>
+				)}
+			</div>
+
+			{/* Quick Links */}
+			<div className="mt-8 flex gap-4">
+				<LinkWithChannel
+					href="/account"
+					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+				>
+					My Account
+				</LinkWithChannel>
+				<LinkWithChannel
+					href="/orders"
+					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+				>
+					View Orders
+				</LinkWithChannel>
+			</div>
+		</div>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/account/messages.ts
+++ b/storefront/src/app/[channel]/(main)/account/messages.ts
@@ -1,0 +1,33 @@
+type StatusMessage = { type: "success" | "error"; text: string };
+
+const accountMessages: Record<string, StatusMessage> = {
+	profile_updated: { type: "success", text: "Profile updated successfully." },
+	profile_error: { type: "error", text: "Failed to update profile." },
+	password_changed: { type: "success", text: "Password changed successfully." },
+	password_error: { type: "error", text: "Failed to change password." },
+	password_required: { type: "error", text: "Current password is required." },
+	passwords_mismatch: { type: "error", text: "Passwords do not match." },
+	password_too_short: { type: "error", text: "Password must be at least 8 characters." },
+};
+
+const addressMessages: Record<string, StatusMessage> = {
+	address_added: { type: "success", text: "Address added successfully." },
+	address_updated: { type: "success", text: "Address updated successfully." },
+	address_deleted: { type: "success", text: "Address deleted successfully." },
+	default_updated: { type: "success", text: "Default address updated." },
+	create_error: { type: "error", text: "Failed to add address." },
+	update_error: { type: "error", text: "Failed to update address." },
+	delete_error: { type: "error", text: "Failed to delete address." },
+	default_error: { type: "error", text: "Failed to update default address." },
+	invalid_address: { type: "error", text: "Invalid address." },
+};
+
+export function getAccountMessage(status: string | undefined): StatusMessage | null {
+	if (!status) return null;
+	return accountMessages[status] ?? null;
+}
+
+export function getAddressMessage(status: string | undefined): StatusMessage | null {
+	if (!status) return null;
+	return addressMessages[status] ?? null;
+}

--- a/storefront/src/app/[channel]/(main)/account/messages.ts
+++ b/storefront/src/app/[channel]/(main)/account/messages.ts
@@ -1,4 +1,4 @@
-type StatusMessage = { type: "success" | "error"; text: string };
+import type { StatusMessage } from "@/ui/components/StatusBanner";
 
 const accountMessages: Record<string, StatusMessage> = {
 	profile_updated: { type: "success", text: "Profile updated successfully." },

--- a/storefront/src/app/[channel]/(main)/account/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/page.tsx
@@ -2,6 +2,7 @@ import { CurrentUserDocument } from "@/gql/graphql";
 import { executeGraphQL } from "@/lib/graphql";
 import { LoginForm } from "@/ui/components/LoginForm";
 import { StatusBanner } from "@/ui/components/StatusBanner";
+import { StoreCreditBadge } from "@/ui/components/StoreCreditBadge";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
 import { updateProfile, changePassword } from "./actions";
 import { getAccountMessage } from "./messages";
@@ -33,7 +34,10 @@ export default async function AccountPage({
 
 	return (
 		<div className="mx-auto max-w-7xl p-8">
-			<h1 className="text-2xl font-bold tracking-tight text-neutral-900">My Account</h1>
+			<div className="flex items-center justify-between">
+				<h1 className="text-2xl font-bold tracking-tight text-neutral-900">My Account</h1>
+				<StoreCreditBadge />
+			</div>
 
 			<StatusBanner message={message} />
 
@@ -146,7 +150,7 @@ export default async function AccountPage({
 			</div>
 
 			{/* Quick Links */}
-			<div className="mt-8 flex gap-4">
+			<div className="mt-8 flex flex-wrap gap-4">
 				<LinkWithChannel
 					href="/account/addresses"
 					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
@@ -158,6 +162,12 @@ export default async function AccountPage({
 					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
 				>
 					View Orders
+				</LinkWithChannel>
+				<LinkWithChannel
+					href="/account/credit"
+					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+				>
+					Store Credit
 				</LinkWithChannel>
 			</div>
 		</div>

--- a/storefront/src/app/[channel]/(main)/account/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/page.tsx
@@ -1,9 +1,11 @@
 import { CurrentUserDocument } from "@/gql/graphql";
 import { executeGraphQL } from "@/lib/graphql";
 import { LoginForm } from "@/ui/components/LoginForm";
+import { StatusBanner } from "@/ui/components/StatusBanner";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
 import { updateProfile, changePassword } from "./actions";
 import { getAccountMessage } from "./messages";
+import { inputClassName, labelClassName } from "./styles";
 
 export const dynamic = "force-dynamic";
 
@@ -33,17 +35,7 @@ export default async function AccountPage({
 		<div className="mx-auto max-w-7xl p-8">
 			<h1 className="text-2xl font-bold tracking-tight text-neutral-900">My Account</h1>
 
-			{message && (
-				<div
-					className={`mt-4 rounded-md p-4 text-sm ${
-						message.type === "success"
-							? "bg-green-50 text-green-800"
-							: "bg-red-50 text-red-800"
-					}`}
-				>
-					{message.text}
-				</div>
-			)}
+			<StatusBanner message={message} />
 
 			<div className="mt-8 grid gap-8 md:grid-cols-2">
 				{/* Profile Section */}
@@ -54,7 +46,7 @@ export default async function AccountPage({
 					<form action={updateProfileWithChannel} className="px-6 py-4">
 						<div className="space-y-4">
 							<div>
-								<label htmlFor="firstName" className="block text-sm font-medium text-neutral-700">
+								<label htmlFor="firstName" className={labelClassName}>
 									First Name
 								</label>
 								<input
@@ -62,11 +54,11 @@ export default async function AccountPage({
 									name="firstName"
 									type="text"
 									defaultValue={user.firstName ?? ""}
-									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+									className={inputClassName}
 								/>
 							</div>
 							<div>
-								<label htmlFor="lastName" className="block text-sm font-medium text-neutral-700">
+								<label htmlFor="lastName" className={labelClassName}>
 									Last Name
 								</label>
 								<input
@@ -74,11 +66,11 @@ export default async function AccountPage({
 									name="lastName"
 									type="text"
 									defaultValue={user.lastName ?? ""}
-									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+									className={inputClassName}
 								/>
 							</div>
 							<div>
-								<label className="block text-sm font-medium text-neutral-700">Email</label>
+								<label className={labelClassName}>Email</label>
 								<p className="mt-1 text-sm text-neutral-600">{user.email}</p>
 							</div>
 						</div>
@@ -99,7 +91,7 @@ export default async function AccountPage({
 					<form action={changePasswordWithChannel} className="px-6 py-4">
 						<div className="space-y-4">
 							<div>
-								<label htmlFor="oldPassword" className="block text-sm font-medium text-neutral-700">
+								<label htmlFor="oldPassword" className={labelClassName}>
 									Current Password
 								</label>
 								<input
@@ -108,11 +100,11 @@ export default async function AccountPage({
 									type="password"
 									required
 									autoComplete="current-password"
-									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+									className={inputClassName}
 								/>
 							</div>
 							<div>
-								<label htmlFor="newPassword" className="block text-sm font-medium text-neutral-700">
+								<label htmlFor="newPassword" className={labelClassName}>
 									New Password
 								</label>
 								<input
@@ -122,13 +114,13 @@ export default async function AccountPage({
 									required
 									minLength={8}
 									autoComplete="new-password"
-									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+									className={inputClassName}
 								/>
 							</div>
 							<div>
 								<label
 									htmlFor="confirmPassword"
-									className="block text-sm font-medium text-neutral-700"
+									className={labelClassName}
 								>
 									Confirm New Password
 								</label>
@@ -139,7 +131,7 @@ export default async function AccountPage({
 									required
 									minLength={8}
 									autoComplete="new-password"
-									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+									className={inputClassName}
 								/>
 							</div>
 						</div>

--- a/storefront/src/app/[channel]/(main)/account/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/page.tsx
@@ -1,0 +1,173 @@
+import { CurrentUserDocument } from "@/gql/graphql";
+import { executeGraphQL } from "@/lib/graphql";
+import { LoginForm } from "@/ui/components/LoginForm";
+import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
+import { updateProfile, changePassword } from "./actions";
+import { getAccountMessage } from "./messages";
+
+export const dynamic = "force-dynamic";
+
+export default async function AccountPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ channel: string }>;
+	searchParams: Promise<{ status?: string }>;
+}) {
+	const { channel } = await params;
+	const { status } = await searchParams;
+
+	const { me: user } = await executeGraphQL(CurrentUserDocument, {
+		cache: "no-cache",
+	});
+
+	if (!user) {
+		return <LoginForm />;
+	}
+
+	const message = getAccountMessage(status);
+	const updateProfileWithChannel = updateProfile.bind(null, channel);
+	const changePasswordWithChannel = changePassword.bind(null, channel);
+
+	return (
+		<div className="mx-auto max-w-7xl p-8">
+			<h1 className="text-2xl font-bold tracking-tight text-neutral-900">My Account</h1>
+
+			{message && (
+				<div
+					className={`mt-4 rounded-md p-4 text-sm ${
+						message.type === "success"
+							? "bg-green-50 text-green-800"
+							: "bg-red-50 text-red-800"
+					}`}
+				>
+					{message.text}
+				</div>
+			)}
+
+			<div className="mt-8 grid gap-8 md:grid-cols-2">
+				{/* Profile Section */}
+				<div className="rounded-lg border bg-white">
+					<div className="border-b px-6 py-4">
+						<h2 className="text-lg font-semibold text-neutral-900">Profile</h2>
+					</div>
+					<form action={updateProfileWithChannel} className="px-6 py-4">
+						<div className="space-y-4">
+							<div>
+								<label htmlFor="firstName" className="block text-sm font-medium text-neutral-700">
+									First Name
+								</label>
+								<input
+									id="firstName"
+									name="firstName"
+									type="text"
+									defaultValue={user.firstName ?? ""}
+									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+								/>
+							</div>
+							<div>
+								<label htmlFor="lastName" className="block text-sm font-medium text-neutral-700">
+									Last Name
+								</label>
+								<input
+									id="lastName"
+									name="lastName"
+									type="text"
+									defaultValue={user.lastName ?? ""}
+									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+								/>
+							</div>
+							<div>
+								<label className="block text-sm font-medium text-neutral-700">Email</label>
+								<p className="mt-1 text-sm text-neutral-600">{user.email}</p>
+							</div>
+						</div>
+						<button
+							type="submit"
+							className="mt-6 rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+						>
+							Save Changes
+						</button>
+					</form>
+				</div>
+
+				{/* Password Section */}
+				<div className="rounded-lg border bg-white">
+					<div className="border-b px-6 py-4">
+						<h2 className="text-lg font-semibold text-neutral-900">Change Password</h2>
+					</div>
+					<form action={changePasswordWithChannel} className="px-6 py-4">
+						<div className="space-y-4">
+							<div>
+								<label htmlFor="oldPassword" className="block text-sm font-medium text-neutral-700">
+									Current Password
+								</label>
+								<input
+									id="oldPassword"
+									name="oldPassword"
+									type="password"
+									required
+									autoComplete="current-password"
+									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+								/>
+							</div>
+							<div>
+								<label htmlFor="newPassword" className="block text-sm font-medium text-neutral-700">
+									New Password
+								</label>
+								<input
+									id="newPassword"
+									name="newPassword"
+									type="password"
+									required
+									minLength={8}
+									autoComplete="new-password"
+									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+								/>
+							</div>
+							<div>
+								<label
+									htmlFor="confirmPassword"
+									className="block text-sm font-medium text-neutral-700"
+								>
+									Confirm New Password
+								</label>
+								<input
+									id="confirmPassword"
+									name="confirmPassword"
+									type="password"
+									required
+									minLength={8}
+									autoComplete="new-password"
+									className="mt-1 w-full rounded border bg-neutral-50 px-4 py-2"
+								/>
+							</div>
+						</div>
+						<button
+							type="submit"
+							className="mt-6 rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+						>
+							Change Password
+						</button>
+					</form>
+				</div>
+			</div>
+
+			{/* Quick Links */}
+			<div className="mt-8 flex gap-4">
+				<LinkWithChannel
+					href="/account/addresses"
+					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+				>
+					Manage Addresses
+				</LinkWithChannel>
+				<LinkWithChannel
+					href="/orders"
+					className="rounded border px-4 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+				>
+					View Orders
+				</LinkWithChannel>
+			</div>
+		</div>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/account/styles.ts
+++ b/storefront/src/app/[channel]/(main)/account/styles.ts
@@ -1,0 +1,2 @@
+export const inputClassName = "mt-1 w-full rounded border bg-neutral-50 px-4 py-2";
+export const labelClassName = "block text-sm font-medium text-neutral-700";

--- a/storefront/src/checkout/sections/PaymentSection/StoreCreditPayment/StoreCreditPayment.tsx
+++ b/storefront/src/checkout/sections/PaymentSection/StoreCreditPayment/StoreCreditPayment.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useCheckout } from "@/checkout/hooks/useCheckout";
+import { useAlerts } from "@/checkout/hooks/useAlerts";
+import { useTransactionInitializeMutation } from "@/checkout/graphql";
+import { formatMoney } from "@/lib/utils";
+import { storeCreditGatewayId } from "./types";
+
+interface StoreCreditConfig {
+	data?: {
+		storeCreditAvailable?: boolean;
+		balance?: number;
+		currency?: string;
+	};
+}
+
+export const StoreCreditPayment = ({ config }: { config: StoreCreditConfig }) => {
+	const { checkout } = useCheckout();
+	const { showCustomErrors } = useAlerts();
+	const [, transactionInitialize] = useTransactionInitializeMutation();
+
+	const balance = config?.data?.balance ?? 0;
+	const currency = config?.data?.currency ?? "USD";
+	const storeCreditAvailable = config?.data?.storeCreditAvailable ?? false;
+
+	const checkoutTotal = checkout?.totalPrice?.gross?.amount ?? 0;
+	const maxApplicable = Math.min(balance, checkoutTotal);
+
+	const [amount, setAmount] = useState<string>(maxApplicable.toFixed(2));
+	const [isLoading, setIsLoading] = useState(false);
+	const [applied, setApplied] = useState(false);
+	const [appliedAmount, setAppliedAmount] = useState(0);
+
+	const parsedAmount = useMemo(() => {
+		const parsed = parseFloat(amount);
+		if (isNaN(parsed) || parsed < 0) return 0;
+		return Math.min(parsed, maxApplicable);
+	}, [amount, maxApplicable]);
+
+	const remaining = checkoutTotal - parsedAmount;
+
+	if (!storeCreditAvailable || balance <= 0) {
+		return null;
+	}
+
+	const handleApply = async () => {
+		if (parsedAmount <= 0) {
+			showCustomErrors([{ message: "Please enter a valid amount to apply." }]);
+			return;
+		}
+
+		setIsLoading(true);
+
+		try {
+			const result = await transactionInitialize({
+				checkoutId: checkout.id,
+				paymentGateway: {
+					id: storeCreditGatewayId,
+					data: {
+						storeCreditAmount: parsedAmount,
+					},
+				},
+				amount: parsedAmount,
+			});
+
+			if (result.error) {
+				showCustomErrors([
+					{ message: result.error.message || "Failed to apply store credit." },
+				]);
+				setIsLoading(false);
+				return;
+			}
+
+			const transactionData = result.data?.transactionInitialize;
+			if (!transactionData || transactionData.errors?.length) {
+				const errorMessages = transactionData?.errors?.map((err) => ({
+					message: err.message || "Error applying store credit",
+				}));
+				showCustomErrors(errorMessages || [{ message: "Failed to apply store credit." }]);
+				setIsLoading(false);
+				return;
+			}
+
+			setApplied(true);
+			setAppliedAmount(parsedAmount);
+		} catch {
+			showCustomErrors([{ message: "An unexpected error occurred while applying store credit." }]);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	if (applied) {
+		return (
+			<div className="rounded-md border border-green-200 bg-green-50 p-4">
+				<div className="flex items-center gap-2">
+					<svg
+						className="h-5 w-5 text-green-600"
+						fill="none"
+						viewBox="0 0 24 24"
+						strokeWidth={2}
+						stroke="currentColor"
+					>
+						<path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+					</svg>
+					<span className="font-medium text-green-800">
+						Store credit applied: {formatMoney(appliedAmount, currency)}
+					</span>
+				</div>
+				{remaining > 0 && (
+					<p className="mt-2 text-sm text-green-700">
+						Remaining {formatMoney(remaining, currency)} will be charged to your card below.
+					</p>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div className="rounded-md border border-neutral-200 bg-neutral-50 p-4">
+			<h3 className="text-base font-medium text-neutral-900">Store Credit</h3>
+
+			<p className="mt-2 text-sm text-neutral-600">
+				Available balance: <span className="font-semibold">{formatMoney(balance, currency)}</span>
+			</p>
+
+			<div className="mt-4">
+				<label htmlFor="store-credit-amount" className="block text-sm font-medium text-neutral-700">
+					Amount to apply
+				</label>
+				<div className="relative mt-1">
+					<span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-neutral-500">
+						$
+					</span>
+					<input
+						id="store-credit-amount"
+						type="number"
+						step="0.01"
+						min="0"
+						max={maxApplicable}
+						value={amount}
+						onChange={(e) => setAmount(e.target.value)}
+						className="block w-full rounded-md border border-neutral-300 py-2 pl-7 pr-3 text-sm focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500"
+					/>
+				</div>
+			</div>
+
+			<button
+				type="button"
+				onClick={handleApply}
+				disabled={isLoading || parsedAmount <= 0}
+				className="mt-4 w-full rounded-md bg-neutral-900 px-4 py-2.5 text-sm font-medium text-white shadow hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-70"
+			>
+				{isLoading ? "Applying..." : "Apply Store Credit"}
+			</button>
+
+			{parsedAmount > 0 && remaining > 0 && (
+				<p className="mt-3 text-sm text-neutral-500">
+					Remaining {formatMoney(remaining, currency)} will be charged to your card below.
+				</p>
+			)}
+		</div>
+	);
+};

--- a/storefront/src/checkout/sections/PaymentSection/StoreCreditPayment/types.ts
+++ b/storefront/src/checkout/sections/PaymentSection/StoreCreditPayment/types.ts
@@ -1,0 +1,4 @@
+// The gateway ID must match the inventory-ops app ID in Saleor
+// This is the MANIFEST_APP_ID env var from inventory-ops
+export const storeCreditGatewayId = "saleor.app.inventory-ops";
+export type StoreCreditGatewayId = typeof storeCreditGatewayId;

--- a/storefront/src/checkout/sections/PaymentSection/supportedPaymentApps.ts
+++ b/storefront/src/checkout/sections/PaymentSection/supportedPaymentApps.ts
@@ -1,6 +1,9 @@
 import { StripeComponent } from "./StripeV2DropIn/stripeComponent";
 import { stripeV2GatewayId } from "./StripeV2DropIn/types";
+import { StoreCreditPayment } from "./StoreCreditPayment/StoreCreditPayment";
+import { storeCreditGatewayId } from "./StoreCreditPayment/types";
 
 export const paymentMethodToComponent = {
 	[stripeV2GatewayId]: StripeComponent,
+	[storeCreditGatewayId]: StoreCreditPayment,
 };

--- a/storefront/src/graphql/AccountAddressCreate.graphql
+++ b/storefront/src/graphql/AccountAddressCreate.graphql
@@ -1,0 +1,12 @@
+mutation AccountAddressCreate($address: AddressInput!, $type: AddressTypeEnum) {
+	accountAddressCreate(type: $type, input: $address) {
+		user {
+			...UserDetails
+		}
+		errors {
+			message
+			field
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/AccountAddressDelete.graphql
+++ b/storefront/src/graphql/AccountAddressDelete.graphql
@@ -1,0 +1,12 @@
+mutation AccountAddressDelete($id: ID!) {
+	accountAddressDelete(id: $id) {
+		user {
+			...UserDetails
+		}
+		errors {
+			message
+			field
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/AccountAddressUpdate.graphql
+++ b/storefront/src/graphql/AccountAddressUpdate.graphql
@@ -1,0 +1,12 @@
+mutation AccountAddressUpdate($id: ID!, $address: AddressInput!) {
+	accountAddressUpdate(id: $id, input: $address) {
+		user {
+			...UserDetails
+		}
+		errors {
+			message
+			field
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/AccountSetDefaultAddress.graphql
+++ b/storefront/src/graphql/AccountSetDefaultAddress.graphql
@@ -1,0 +1,12 @@
+mutation AccountSetDefaultAddress($id: ID!, $type: AddressTypeEnum!) {
+	accountSetDefaultAddress(id: $id, type: $type) {
+		user {
+			...UserDetails
+		}
+		errors {
+			message
+			field
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/AccountUpdate.graphql
+++ b/storefront/src/graphql/AccountUpdate.graphql
@@ -1,0 +1,12 @@
+mutation AccountUpdate($input: AccountInput!) {
+	accountUpdate(input: $input) {
+		user {
+			...UserDetails
+		}
+		errors {
+			message
+			field
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/AddressFragment.graphql
+++ b/storefront/src/graphql/AddressFragment.graphql
@@ -1,0 +1,17 @@
+fragment AccountAddressDetails on Address {
+	id
+	firstName
+	lastName
+	companyName
+	streetAddress1
+	streetAddress2
+	city
+	cityArea
+	postalCode
+	countryArea
+	country {
+		country
+		code
+	}
+	phone
+}

--- a/storefront/src/graphql/MeWithAddresses.graphql
+++ b/storefront/src/graphql/MeWithAddresses.graphql
@@ -2,21 +2,7 @@ query MeWithAddresses {
 	me {
 		...UserDetails
 		addresses {
-			id
-			firstName
-			lastName
-			companyName
-			streetAddress1
-			streetAddress2
-			city
-			cityArea
-			postalCode
-			countryArea
-			country {
-				country
-				code
-			}
-			phone
+			...AccountAddressDetails
 		}
 		defaultShippingAddress {
 			id

--- a/storefront/src/graphql/MeWithAddresses.graphql
+++ b/storefront/src/graphql/MeWithAddresses.graphql
@@ -1,0 +1,28 @@
+query MeWithAddresses {
+	me {
+		...UserDetails
+		addresses {
+			id
+			firstName
+			lastName
+			companyName
+			streetAddress1
+			streetAddress2
+			city
+			cityArea
+			postalCode
+			countryArea
+			country {
+				country
+				code
+			}
+			phone
+		}
+		defaultShippingAddress {
+			id
+		}
+		defaultBillingAddress {
+			id
+		}
+	}
+}

--- a/storefront/src/graphql/PasswordChange.graphql
+++ b/storefront/src/graphql/PasswordChange.graphql
@@ -1,0 +1,9 @@
+mutation PasswordChange($newPassword: String!, $oldPassword: String) {
+	passwordChange(newPassword: $newPassword, oldPassword: $oldPassword) {
+		errors {
+			message
+			field
+			code
+		}
+	}
+}

--- a/storefront/src/lib/customer-api.ts
+++ b/storefront/src/lib/customer-api.ts
@@ -1,0 +1,102 @@
+import { cookies } from "next/headers";
+
+// Types for customer API responses
+
+export type StoreCreditBalance = {
+	balance: number;
+	currency: string;
+};
+
+export type CreditTransaction = {
+	id: string;
+	type: string;
+	amount: number;
+	currency: string;
+	balanceAfter: number;
+	note: string | null;
+	createdAt: string;
+};
+
+export type CreditHistoryResponse = {
+	transactions: CreditTransaction[];
+	total: number;
+	limit: number;
+	offset: number;
+};
+
+export type CustomerGroup = {
+	id: string;
+	name: string;
+	discountPercent: number;
+};
+
+export type CustomerGroupsResponse = {
+	groups: CustomerGroup[];
+};
+
+async function getAccessToken(): Promise<string | null> {
+	const cookieStore = await cookies();
+	return cookieStore.get("saleor_auth_access_token")?.value ?? null;
+}
+
+function getBaseUrl(): string | null {
+	const url = process.env.INVENTORY_OPS_URL;
+	if (!url) {
+		console.warn("INVENTORY_OPS_URL environment variable is not set");
+		return null;
+	}
+	return url.replace(/\/$/, "");
+}
+
+async function fetchCustomerAPI<T>(path: string): Promise<T | null> {
+	const token = await getAccessToken();
+	if (!token) {
+		return null;
+	}
+
+	const baseUrl = getBaseUrl();
+	if (!baseUrl) {
+		return null;
+	}
+
+	try {
+		const response = await fetch(`${baseUrl}${path}`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+			},
+			cache: "no-cache",
+		});
+
+		if (response.status === 401) {
+			return null;
+		}
+
+		if (!response.ok) {
+			console.warn(`Customer API error: ${response.status} ${response.statusText} for ${path}`);
+			return null;
+		}
+
+		return (await response.json()) as T;
+	} catch (error) {
+		console.warn(`Customer API network error for ${path}:`, error);
+		return null;
+	}
+}
+
+export async function getStoreCredit(): Promise<StoreCreditBalance | null> {
+	return fetchCustomerAPI<StoreCreditBalance>("/api/customer/credit/balance");
+}
+
+export async function getCreditHistory(
+	limit = 50,
+	offset = 0,
+): Promise<CreditHistoryResponse | null> {
+	return fetchCustomerAPI<CreditHistoryResponse>(
+		`/api/customer/credit/history?limit=${limit}&offset=${offset}`,
+	);
+}
+
+export async function getCustomerGroups(): Promise<CustomerGroupsResponse | null> {
+	return fetchCustomerAPI<CustomerGroupsResponse>("/api/customer/groups");
+}

--- a/storefront/src/ui/components/StatusBanner.tsx
+++ b/storefront/src/ui/components/StatusBanner.tsx
@@ -1,4 +1,4 @@
-type StatusMessage = { type: "success" | "error"; text: string };
+export type StatusMessage = { type: "success" | "error"; text: string };
 
 export function StatusBanner({ message }: { message: StatusMessage | null }) {
 	if (!message) return null;

--- a/storefront/src/ui/components/StatusBanner.tsx
+++ b/storefront/src/ui/components/StatusBanner.tsx
@@ -1,0 +1,15 @@
+type StatusMessage = { type: "success" | "error"; text: string };
+
+export function StatusBanner({ message }: { message: StatusMessage | null }) {
+	if (!message) return null;
+
+	return (
+		<div
+			className={`mt-4 rounded-md p-4 text-sm ${
+				message.type === "success" ? "bg-green-50 text-green-800" : "bg-red-50 text-red-800"
+			}`}
+		>
+			{message.text}
+		</div>
+	);
+}

--- a/storefront/src/ui/components/StoreCreditBadge.tsx
+++ b/storefront/src/ui/components/StoreCreditBadge.tsx
@@ -1,0 +1,29 @@
+import { getStoreCredit } from "@/lib/customer-api";
+import { formatMoney } from "@/lib/utils";
+
+export async function StoreCreditBadge() {
+	const credit = await getStoreCredit();
+
+	if (!credit || credit.balance <= 0) {
+		return null;
+	}
+
+	return (
+		<div className="inline-flex items-center gap-1.5 rounded-full bg-green-50 px-3 py-1 text-sm font-medium text-green-700">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 20 20"
+				fill="currentColor"
+				className="h-4 w-4"
+				aria-hidden="true"
+			>
+				<path
+					fillRule="evenodd"
+					d="M1 4a1 1 0 011-1h16a1 1 0 011 1v8a1 1 0 01-1 1H2a1 1 0 01-1-1V4zm12 4a3 3 0 11-6 0 3 3 0 016 0zM4 9a1 1 0 100-2 1 1 0 000 2zm13-1a1 1 0 11-2 0 1 1 0 012 0zM1.75 14.5a.75.75 0 000 1.5c4.417 0 8.693.603 12.749 1.73 1.111.309 2.251-.512 2.251-1.696v-.784a.75.75 0 00-1.5 0v.784a.272.272 0 01-.35.25A49.043 49.043 0 001.75 14.5z"
+					clipRule="evenodd"
+				/>
+			</svg>
+			<span>Store Credit: {formatMoney(credit.balance, credit.currency)}</span>
+		</div>
+	);
+}

--- a/storefront/src/ui/components/nav/components/UserMenu/UserMenu.tsx
+++ b/storefront/src/ui/components/nav/components/UserMenu/UserMenu.tsx
@@ -8,12 +8,15 @@ import { UserAvatar } from "./components/UserAvatar";
 import { type UserDetailsFragment } from "@/gql/graphql";
 import { logout } from "@/app/actions";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
+import { formatMoney } from "@/lib/utils";
 
 type Props = {
 	user: UserDetailsFragment;
+	creditBalance?: number;
+	creditCurrency?: string;
 };
 
-export function UserMenu({ user }: Props) {
+export function UserMenu({ user, creditBalance = 0, creditCurrency = "USD" }: Props) {
 	return (
 		<Menu as="div" className="relative">
 			<Menu.Button className="relative flex rounded-full bg-neutral-200 text-sm focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-neutral-800">
@@ -31,6 +34,12 @@ export function UserMenu({ user }: Props) {
 			>
 				<Menu.Items className="absolute right-0 z-10 mt-2 w-48 origin-top-right divide-y divide-neutral-200 bg-white py-1 text-start shadow ring-1 ring-neutral-200 ring-opacity-5 focus:outline-none">
 					<UserInfo user={user} />
+					{creditBalance > 0 && (
+						<div className="px-4 py-2 text-sm text-green-700">
+							<span className="font-medium">Store Credit:</span>{" "}
+							{formatMoney(creditBalance, creditCurrency)}
+						</div>
+					)}
 					<div className="flex flex-col px-1 py-1">
 						<Menu.Item>
 							{({ active }) => (

--- a/storefront/src/ui/components/nav/components/UserMenu/UserMenu.tsx
+++ b/storefront/src/ui/components/nav/components/UserMenu/UserMenu.tsx
@@ -35,13 +35,26 @@ export function UserMenu({ user }: Props) {
 						<Menu.Item>
 							{({ active }) => (
 								<LinkWithChannel
+									href="/account"
+									className={clsx(
+										active && "bg-neutral-100",
+										"block px-4 py-2 text-sm font-medium text-neutral-500 hover:text-neutral-700",
+									)}
+								>
+									My Account
+								</LinkWithChannel>
+							)}
+						</Menu.Item>
+						<Menu.Item>
+							{({ active }) => (
+								<LinkWithChannel
 									href="/orders"
 									className={clsx(
 										active && "bg-neutral-100",
 										"block px-4 py-2 text-sm font-medium text-neutral-500 hover:text-neutral-700",
 									)}
 								>
-									My orders
+									My Orders
 								</LinkWithChannel>
 							)}
 						</Menu.Item>

--- a/storefront/src/ui/components/nav/components/UserMenu/UserMenuContainer.tsx
+++ b/storefront/src/ui/components/nav/components/UserMenu/UserMenuContainer.tsx
@@ -2,6 +2,7 @@ import { UserIcon } from "lucide-react";
 import { UserMenu } from "./UserMenu";
 import { CurrentUserDocument } from "@/gql/graphql";
 import { executeGraphQL } from "@/lib/graphql";
+import { getStoreCredit } from "@/lib/customer-api";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
 
 export async function UserMenuContainer() {
@@ -10,7 +11,14 @@ export async function UserMenuContainer() {
 	});
 
 	if (user) {
-		return <UserMenu user={user} />;
+		const credit = await getStoreCredit();
+		return (
+			<UserMenu
+				user={user}
+				creditBalance={credit?.balance ?? 0}
+				creditCurrency={credit?.currency ?? "USD"}
+			/>
+		);
 	} else {
 		return (
 			<LinkWithChannel href="/login" className="h-6 w-6 flex-shrink-0">


### PR DESCRIPTION
## Summary

- **Phase 1**: Storefront account pages — profile, address book, order history
- **Phase 2**: Store credit visibility — customers see credit balance on their account page
- **Phase 3**: Customer group discounts — POS and Buylist apply group-based premiums
- **Phase 4**: Store credit online payment — customers spend credit at checkout, with partial application and Stripe fallback for remainder

## Key changes

### Storefront
- Account profile page with address book (add/edit/delete/set-default)
- Order history with detail view
- Store credit balance display on account page
- StoreCreditPayment checkout component with partial amount input

### inventory-ops
- Customer API bridge (`/api/customer/`) for storefront credit visibility
- 5 Saleor payment webhooks (gateway-init, tx-init, tx-charge, tx-refund, tx-cancel)
- `credit-payment-service.ts` with atomic Serializable transactions
- ONLINE_PAYMENT/ONLINE_REFUND enum values, sourceOrderId field

### POS
- Group discount application in transactions
- Optimized subtotal calculation using denormalized field

### Buylist
- Group premium in create/createAndPay mutations
- Extracted shared helpers to reduce duplication

## Test plan

- [ ] Verify storefront account pages load with authenticated user
- [ ] Verify store credit balance displays correctly on account page
- [ ] Verify store credit payment option appears in checkout when balance > 0
- [ ] Verify partial credit application works (apply X of Y, remainder to Stripe)
- [ ] Verify POS group discounts apply correctly to transactions
- [ ] Verify inventory-ops compiles with 0 new TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)