### PR TITLE
feat: 6-tier collection import card matcher

### DIFF
--- a/scripts/meilisearch-delta-sync.py
+++ b/scripts/meilisearch-delta-sync.py
@@ -230,6 +230,8 @@ def transform_product(product: dict) -> dict:
     set_name = get_attribute_value(attrs, "mtg-set-name") or ""
     set_code = get_attribute_value(attrs, "mtg-set-code") or ""
     collector_number = get_attribute_value(attrs, "mtg-collector-number") or ""
+    tcgplayer_id = get_attribute_value(attrs, "mtg-tcgplayer-id") or ""
+    scryfall_id = get_attribute_value(attrs, "mtg-scryfall-id") or ""
     rarity = get_attribute_value(attrs, "mtg-rarity") or ""
     colors = get_attribute_value(attrs, "mtg-colors") or ""
     mana_cost = get_attribute_value(attrs, "mtg-mana-cost") or ""
@@ -292,6 +294,8 @@ def transform_product(product: dict) -> dict:
         "set_name": set_name,
         "set_code": set_code.upper() if set_code else "",
         "collector_number": collector_number,
+        "tcgplayer_id": tcgplayer_id,
+        "scryfall_id": scryfall_id,
         "rarity": rarity.lower() if rarity else "",
         "colors": colors,
         "mana_cost": mana_cost,

--- a/scripts/sync-meilisearch.py
+++ b/scripts/sync-meilisearch.py
@@ -227,6 +227,9 @@ def transform_product(product: dict) -> dict:
     mana_cost = get_attribute_value(attrs, "mtg-mana-cost") or ""
     type_line = get_attribute_value(attrs, "mtg-type-line") or ""
     oracle_text = get_attribute_value(attrs, "mtg-oracle-text") or ""
+    # IDs for deterministic collection import matching
+    tcgplayer_id = get_attribute_value(attrs, "mtg-tcgplayer-id") or ""
+    scryfall_id = get_attribute_value(attrs, "mtg-scryfall-id") or ""
     # NEW: Council recommendations - additional filterable attributes
     mana_value_raw = get_attribute_value(attrs, "mtg-mana-value")
     mana_value = int(float(mana_value_raw)) if mana_value_raw else 0
@@ -303,6 +306,8 @@ def transform_product(product: dict) -> dict:
         "set_name": set_name,
         "set_code": set_code.upper() if set_code else "",
         "collector_number": collector_number,
+        "tcgplayer_id": tcgplayer_id,
+        "scryfall_id": scryfall_id,
         "rarity": rarity.lower() if rarity else "",
         "colors": colors,
         "mana_cost": mana_cost,
@@ -397,6 +402,10 @@ def setup_meilisearch_index(index_name: str, full_reindex: bool = False):
             "mana_value",     # CMC for "show me all 3-drops"
             "color_identity", # Commander players need this
             "keywords",       # Flying, Trample, etc.
+            # Collection import deterministic matching
+            "collector_number",  # Set code + collector number = unique card
+            "tcgplayer_id",      # TCGPlayer product ID lookup
+            "scryfall_id",       # Scryfall UUID lookup
         ],
         "sortableAttributes": [
             "name",


### PR DESCRIPTION
## Summary

- Replaces broken name-only card matcher with 6-tier deterministic matching strategy: SKU construction → Scryfall filter → TCGPlayer filter → set+collector number → name+set → name-only
- Adds `tcgplayer_id`, `scryfall_id`, `collector_number` as Meilisearch filterable attributes (both sync scripts + TypeScript document transformer)
- Adds `scryfallId` / `foil` CSV column parsing with aliases for common formats
- Each match result includes confidence score (1.0→0.5) and method used; unmatched lines include diagnostic reasons

## Test plan

- [ ] Re-index Meilisearch with updated settings (`python scripts/sync-meilisearch.py`)
- [ ] Import CSV with scryfall IDs → verify SKU construction matches (confidence 1.0)
- [ ] Import CSV with TCGPlayer IDs → verify tcgplayer_filter matches (confidence 0.95)
- [ ] Import CSV with set+collector number → verify set_number matches (confidence 0.95)
- [ ] Verify unmatched lines include diagnostic array explaining why each tier failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)