### PR TITLE
fix: address all Codex review concerns from PRs #50-#61

### DIFF
--- a/.claude/hooks/pre-pr-lint.sh
+++ b/.claude/hooks/pre-pr-lint.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Pre-PR Lint Gate — blocks `gh pr create` if lint or type-check fails.
+#
+# Runs the same checks as CI's test-platform.yml:
+#   1. saleor-apps: pnpm turbo run lint (custom apps only)
+#   2. storefront: pnpm lint + tsc --noEmit
+#
+# Hook type: PreToolUse (Bash matcher)
+# Reads stdin JSON, checks if command contains "gh pr create".
+# Outputs JSON { "decision": "block", "reason": "..." } on failure.
+
+# Read stdin (hook input JSON)
+INPUT=$(cat)
+
+# Extract the command from the hook input
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only gate on `gh pr create` commands
+if [[ -z "$COMMAND" ]] || ! echo "$COMMAND" | grep -q 'gh pr create'; then
+  exit 0
+fi
+
+# Determine project root (where this hook lives)
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+
+ERRORS=""
+
+# --- 1. Saleor Apps lint (custom apps only, matches CI) ---
+APPS_DIR="$PROJECT_ROOT/saleor-apps"
+if [[ -d "$APPS_DIR" ]]; then
+  cd "$APPS_DIR"
+
+  # Install deps if needed
+  if [[ ! -d "node_modules" ]]; then
+    pnpm install --frozen-lockfile >/dev/null 2>&1 || true
+  fi
+
+  LINT_OUTPUT=""
+  LINT_OUTPUT=$(pnpm turbo run lint \
+    --filter=saleor-app-inventory-ops \
+    --filter=saleor-app-buylist \
+    --filter=saleor-app-pos 2>&1) || true
+
+  # Check for actual errors (not warnings)
+  if echo "$LINT_OUTPUT" | grep -qE '^\s+\d+:\d+\s+error\s'; then
+    ERROR_LINES=$(echo "$LINT_OUTPUT" | grep -E '\d+:\d+\s+error\s' | head -20)
+    ERRORS="${ERRORS}saleor-apps lint errors:\n${ERROR_LINES}\n\n"
+  elif echo "$LINT_OUTPUT" | grep -q 'Failed:'; then
+    TAIL=$(echo "$LINT_OUTPUT" | tail -10)
+    ERRORS="${ERRORS}saleor-apps lint failed:\n${TAIL}\n\n"
+  fi
+fi
+
+# --- 2. Storefront lint + type check ---
+SF_DIR="$PROJECT_ROOT/storefront"
+if [[ -d "$SF_DIR" ]]; then
+  cd "$SF_DIR"
+
+  if [[ ! -d "node_modules" ]]; then
+    pnpm install --frozen-lockfile >/dev/null 2>&1 || true
+  fi
+
+  # Generate GraphQL types if needed (lint depends on them)
+  if [[ ! -f "src/gql/graphql.ts" ]]; then
+    USE_SCHEMA_FILE=true pnpm generate >/dev/null 2>&1 || true
+  fi
+
+  LINT_OUTPUT=""
+  LINT_OUTPUT=$(pnpm lint 2>&1) || true
+  if echo "$LINT_OUTPUT" | grep -qE '(error|Error)'; then
+    ERRORS="${ERRORS}storefront lint failed:\n$(echo "$LINT_OUTPUT" | tail -10)\n\n"
+  fi
+
+  TSC_OUTPUT=""
+  TSC_OUTPUT=$(pnpm exec tsc --noEmit 2>&1) || true
+  if echo "$TSC_OUTPUT" | grep -qE '(error TS|Error)'; then
+    ERRORS="${ERRORS}storefront tsc failed:\n$(echo "$TSC_OUTPUT" | grep 'error TS' | head -15)\n\n"
+  fi
+fi
+
+# --- Report results ---
+if [[ -n "$ERRORS" ]]; then
+  REASON=$(echo -e "$ERRORS" | jq -Rs .)
+  echo "{\"decision\":\"block\",\"reason\":${REASON}}"
+  exit 0
+fi
+
+# All checks passed
+exit 0

--- a/.claude/hooks/pre-pr-lint.sh
+++ b/.claude/hooks/pre-pr-lint.sh
@@ -36,19 +36,20 @@ if [[ -d "$APPS_DIR" ]]; then
     pnpm install --frozen-lockfile >/dev/null 2>&1 || true
   fi
 
-  LINT_OUTPUT=""
+  APPS_LINT_EXIT=0
   LINT_OUTPUT=$(pnpm turbo run lint \
     --filter=saleor-app-inventory-ops \
     --filter=saleor-app-buylist \
-    --filter=saleor-app-pos 2>&1) || true
+    --filter=saleor-app-pos 2>&1) || APPS_LINT_EXIT=$?
 
-  # Check for actual errors (not warnings)
-  if echo "$LINT_OUTPUT" | grep -qE '^\s+\d+:\d+\s+error\s'; then
+  if [[ $APPS_LINT_EXIT -ne 0 ]]; then
+    # Extract error lines (not warnings) for a clear message
     ERROR_LINES=$(echo "$LINT_OUTPUT" | grep -E '\d+:\d+\s+error\s' | head -20)
-    ERRORS="${ERRORS}saleor-apps lint errors:\n${ERROR_LINES}\n\n"
-  elif echo "$LINT_OUTPUT" | grep -q 'Failed:'; then
-    TAIL=$(echo "$LINT_OUTPUT" | tail -10)
-    ERRORS="${ERRORS}saleor-apps lint failed:\n${TAIL}\n\n"
+    if [[ -n "$ERROR_LINES" ]]; then
+      ERRORS="${ERRORS}saleor-apps lint errors:\n${ERROR_LINES}\n\n"
+    else
+      ERRORS="${ERRORS}saleor-apps lint failed:\n$(echo "$LINT_OUTPUT" | tail -10)\n\n"
+    fi
   fi
 fi
 
@@ -66,16 +67,16 @@ if [[ -d "$SF_DIR" ]]; then
     USE_SCHEMA_FILE=true pnpm generate >/dev/null 2>&1 || true
   fi
 
-  LINT_OUTPUT=""
-  LINT_OUTPUT=$(pnpm lint 2>&1) || true
-  if echo "$LINT_OUTPUT" | grep -qE '(error|Error)'; then
-    ERRORS="${ERRORS}storefront lint failed:\n$(echo "$LINT_OUTPUT" | tail -10)\n\n"
+  LINT_EXIT=0
+  LINT_OUTPUT=$(pnpm lint 2>&1) || LINT_EXIT=$?
+  if [[ $LINT_EXIT -ne 0 ]]; then
+    ERRORS="${ERRORS}storefront lint failed (exit $LINT_EXIT):\n$(echo "$LINT_OUTPUT" | tail -15)\n\n"
   fi
 
-  TSC_OUTPUT=""
-  TSC_OUTPUT=$(pnpm exec tsc --noEmit 2>&1) || true
-  if echo "$TSC_OUTPUT" | grep -qE '(error TS|Error)'; then
-    ERRORS="${ERRORS}storefront tsc failed:\n$(echo "$TSC_OUTPUT" | grep 'error TS' | head -15)\n\n"
+  TSC_EXIT=0
+  TSC_OUTPUT=$(pnpm exec tsc --noEmit 2>&1) || TSC_EXIT=$?
+  if [[ $TSC_EXIT -ne 0 ]]; then
+    ERRORS="${ERRORS}storefront tsc failed (exit $TSC_EXIT):\n$(echo "$TSC_OUTPUT" | tail -15)\n\n"
   fi
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,19 @@
   "enabledPlugins": {
     "local-review@agent37-skills": true,
     "pr-review-toolkit@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-pr-lint.sh",
+            "timeout": 120000
+          }
+        ]
+      }
+    ]
   }
 }

--- a/storefront/next.config.js
+++ b/storefront/next.config.js
@@ -65,9 +65,9 @@ const config = {
 	async headers() {
 		const isDev = process.env.NODE_ENV === "development";
 		return [
-			// Versioned assets (hashed filenames) — cache forever
+			// Versioned static assets (hashed filenames) — cache forever
 			{
-				source: "/:path*",
+				source: "/_next/static/:path*",
 				has: [{ type: "query", key: "v" }],
 				headers: [
 					{

--- a/storefront/src/app/[channel]/(main)/account/actions.ts
+++ b/storefront/src/app/[channel]/(main)/account/actions.ts
@@ -17,12 +17,17 @@ export async function updateProfile(channelSlug: string, formData: FormData) {
 	const firstName = formData.get("firstName")?.toString() ?? "";
 	const lastName = formData.get("lastName")?.toString() ?? "";
 
-	const { accountUpdate } = await executeGraphQL(AccountUpdateDocument, {
-		variables: { input: { firstName, lastName } },
-		cache: "no-cache",
-	});
+	let result;
+	try {
+		result = await executeGraphQL(AccountUpdateDocument, {
+			variables: { input: { firstName, lastName } },
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account?status=profile_error`);
+	}
 
-	const errors = accountUpdate?.errors ?? [];
+	const errors = result.accountUpdate?.errors ?? [];
 	if (errors.length > 0) {
 		redirect(`/${channelSlug}/account?status=profile_error`);
 	}
@@ -47,12 +52,17 @@ export async function changePassword(channelSlug: string, formData: FormData) {
 		redirect(`/${channelSlug}/account?status=password_too_short`);
 	}
 
-	const { passwordChange } = await executeGraphQL(PasswordChangeDocument, {
-		variables: { newPassword, oldPassword },
-		cache: "no-cache",
-	});
+	let result;
+	try {
+		result = await executeGraphQL(PasswordChangeDocument, {
+			variables: { newPassword, oldPassword },
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account?status=password_error`);
+	}
 
-	const errors = passwordChange?.errors ?? [];
+	const errors = result.passwordChange?.errors ?? [];
 	if (errors.length > 0) {
 		redirect(`/${channelSlug}/account?status=password_error`);
 	}
@@ -65,12 +75,17 @@ export async function deleteAddress(channelSlug: string, addressId: string) {
 		redirect(`/${channelSlug}/account/addresses?status=invalid_address`);
 	}
 
-	const { accountAddressDelete } = await executeGraphQL(AccountAddressDeleteDocument, {
-		variables: { id: addressId },
-		cache: "no-cache",
-	});
+	let result;
+	try {
+		result = await executeGraphQL(AccountAddressDeleteDocument, {
+			variables: { id: addressId },
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account/addresses?status=delete_error`);
+	}
 
-	const errors = accountAddressDelete?.errors ?? [];
+	const errors = result.accountAddressDelete?.errors ?? [];
 	if (errors.length > 0) {
 		redirect(`/${channelSlug}/account/addresses?status=delete_error`);
 	}
@@ -83,12 +98,17 @@ export async function setDefaultAddress(channelSlug: string, addressId: string, 
 		redirect(`/${channelSlug}/account/addresses?status=invalid_address`);
 	}
 
-	const { accountSetDefaultAddress } = await executeGraphQL(AccountSetDefaultAddressDocument, {
-		variables: { id: addressId, type },
-		cache: "no-cache",
-	});
+	let result;
+	try {
+		result = await executeGraphQL(AccountSetDefaultAddressDocument, {
+			variables: { id: addressId, type },
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account/addresses?status=default_error`);
+	}
 
-	const errors = accountSetDefaultAddress?.errors ?? [];
+	const errors = result.accountSetDefaultAddress?.errors ?? [];
 	if (errors.length > 0) {
 		redirect(`/${channelSlug}/account/addresses?status=default_error`);
 	}
@@ -99,12 +119,17 @@ export async function setDefaultAddress(channelSlug: string, addressId: string, 
 export async function createAddress(channelSlug: string, formData: FormData) {
 	const address = extractAddressFromForm(formData);
 
-	const { accountAddressCreate } = await executeGraphQL(AccountAddressCreateDocument, {
-		variables: { address },
-		cache: "no-cache",
-	});
+	let result;
+	try {
+		result = await executeGraphQL(AccountAddressCreateDocument, {
+			variables: { address },
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account/addresses?status=create_error`);
+	}
 
-	const errors = accountAddressCreate?.errors ?? [];
+	const errors = result.accountAddressCreate?.errors ?? [];
 	if (errors.length > 0) {
 		redirect(`/${channelSlug}/account/addresses?status=create_error`);
 	}
@@ -119,12 +144,17 @@ export async function updateAddress(channelSlug: string, addressId: string, form
 
 	const address = extractAddressFromForm(formData);
 
-	const { accountAddressUpdate } = await executeGraphQL(AccountAddressUpdateDocument, {
-		variables: { id: addressId, address },
-		cache: "no-cache",
-	});
+	let result;
+	try {
+		result = await executeGraphQL(AccountAddressUpdateDocument, {
+			variables: { id: addressId, address },
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account/addresses?status=update_error`);
+	}
 
-	const errors = accountAddressUpdate?.errors ?? [];
+	const errors = result.accountAddressUpdate?.errors ?? [];
 	if (errors.length > 0) {
 		redirect(`/${channelSlug}/account/addresses?status=update_error`);
 	}

--- a/storefront/src/app/[channel]/(main)/account/addresses/AddressCard.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/AddressCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTransition } from "react";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
 import { deleteAddress, setDefaultAddress } from "../actions";
 import { AddressTypeEnum } from "@/gql/graphql";
@@ -13,6 +14,8 @@ type Props = {
 };
 
 export function AddressCard({ address, channelSlug, isDefaultShipping, isDefaultBilling }: Props) {
+	const [isPending, startTransition] = useTransition();
+
 	return (
 		<div className="rounded-lg border bg-white p-4">
 			<div className="mb-2 flex flex-wrap gap-1">
@@ -52,7 +55,8 @@ export function AddressCard({ address, channelSlug, isDefaultShipping, isDefault
 				</LinkWithChannel>
 				{!isDefaultShipping && (
 					<button
-						onClick={() => setDefaultAddress(channelSlug, address.id, AddressTypeEnum.Shipping)}
+						disabled={isPending}
+						onClick={() => startTransition(() => setDefaultAddress(channelSlug, address.id, AddressTypeEnum.Shipping))}
 						className="text-xs font-medium text-neutral-600 hover:text-neutral-900"
 					>
 						Set as Shipping
@@ -60,16 +64,18 @@ export function AddressCard({ address, channelSlug, isDefaultShipping, isDefault
 				)}
 				{!isDefaultBilling && (
 					<button
-						onClick={() => setDefaultAddress(channelSlug, address.id, AddressTypeEnum.Billing)}
+						disabled={isPending}
+						onClick={() => startTransition(() => setDefaultAddress(channelSlug, address.id, AddressTypeEnum.Billing))}
 						className="text-xs font-medium text-neutral-600 hover:text-neutral-900"
 					>
 						Set as Billing
 					</button>
 				)}
 				<button
+					disabled={isPending}
 					onClick={() => {
 						if (confirm("Delete this address?")) {
-							deleteAddress(channelSlug, address.id);
+							startTransition(() => deleteAddress(channelSlug, address.id));
 						}
 					}}
 					className="text-xs font-medium text-red-600 hover:text-red-800"

--- a/storefront/src/app/[channel]/(main)/account/addresses/AddressForm.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/AddressForm.tsx
@@ -1,9 +1,17 @@
 "use client";
 
+import { CountryCode } from "@/gql/graphql";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
 import { createAddress, updateAddress } from "../actions";
 import { inputClassName, labelClassName } from "../styles";
 import type { AccountAddress } from "./types";
+
+const countryNames = new Intl.DisplayNames("en-US", { type: "region" });
+
+const countryOptions = Object.values(CountryCode).map((code) => ({
+	code,
+	name: countryNames.of(code) ?? code,
+}));
 
 type Props = {
 	channelSlug: string;
@@ -135,8 +143,11 @@ export function AddressForm({ channelSlug, address }: Props) {
 						defaultValue={address?.country.code ?? "US"}
 						className={inputClassName}
 					>
-						<option value="US">United States</option>
-						<option value="CA">Canada</option>
+						{countryOptions.map(({ code, name }) => (
+							<option key={code} value={code}>
+								{name}
+							</option>
+						))}
 					</select>
 				</div>
 				<div className="sm:col-span-2">

--- a/storefront/src/app/[channel]/(main)/account/addresses/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/addresses/page.tsx
@@ -24,7 +24,7 @@ export default async function AddressesPage({
 	});
 
 	if (!user) {
-		return <LoginForm />;
+		return <LoginForm redirectTo={`/${channel}/account/addresses`} />;
 	}
 
 	const addresses = user.addresses ?? [];

--- a/storefront/src/app/[channel]/(main)/account/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/page.tsx
@@ -25,7 +25,7 @@ export default async function AccountPage({
 	});
 
 	if (!user) {
-		return <LoginForm />;
+		return <LoginForm redirectTo={`/${channel}/account`} />;
 	}
 
 	const message = getAccountMessage(status);

--- a/storefront/src/checkout/hooks/useAutoSaveAddressForm.ts
+++ b/storefront/src/checkout/hooks/useAutoSaveAddressForm.ts
@@ -1,5 +1,5 @@
 import { pick } from "lodash-es";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { type AddressFormData } from "@/checkout/components/AddressForm/types";
 import { useAddressFormSchema } from "@/checkout/components/AddressForm/useAddressFormSchema";
 import { type CountryCode } from "@/checkout/graphql";
@@ -33,6 +33,10 @@ export const useAutoSaveAddressForm = ({
 	const form = useForm<AutoSaveAddressFormData>({ ...formProps, validationSchema });
 	const { values, validateForm, dirty, handleBlur, handleChange } = form;
 
+	// Keep a ref to latest values so partialSubmit always reads current state
+	const valuesRef = useRef(values);
+	valuesRef.current = values;
+
 	const debouncedSubmit = useDebouncedSubmit(onSubmit);
 
 	const formHelpers = pick(form, [
@@ -49,14 +53,17 @@ export const useAutoSaveAddressForm = ({
 	]) as FormHelpers<AutoSaveAddressFormData>;
 
 	// partial submit for guest address form — validates before submitting
+	// Uses valuesRef to always read the latest values, even when called
+	// immediately after handleChange (before React re-renders with new state)
 	const partialSubmit = useCallback(async () => {
-		const formErrors = validateForm(values);
+		const currentValues = valuesRef.current;
+		const formErrors = validateForm(currentValues);
 
 		if (!hasErrors(formErrors) && dirty) {
 			setCheckoutUpdateState("loading");
-			void debouncedSubmit({ ...initialValues, countryCode: values.countryCode, ...values }, formHelpers);
+			void debouncedSubmit({ ...initialValues, countryCode: currentValues.countryCode, ...currentValues }, formHelpers);
 		}
-	}, [validateForm, values, dirty, setCheckoutUpdateState, debouncedSubmit, initialValues, formHelpers]);
+	}, [validateForm, dirty, setCheckoutUpdateState, debouncedSubmit, initialValues, formHelpers]);
 
 	const onChange: ChangeHandler = (event) => {
 		const { name, value } = event.target;

--- a/storefront/src/checkout/hooks/useAutoSaveAddressForm.ts
+++ b/storefront/src/checkout/hooks/useAutoSaveAddressForm.ts
@@ -1,5 +1,5 @@
 import { pick } from "lodash-es";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { type AddressFormData } from "@/checkout/components/AddressForm/types";
 import { useAddressFormSchema } from "@/checkout/components/AddressForm/useAddressFormSchema";
 import { type CountryCode } from "@/checkout/graphql";
@@ -35,7 +35,9 @@ export const useAutoSaveAddressForm = ({
 
 	// Keep a ref to latest values so partialSubmit always reads current state
 	const valuesRef = useRef(values);
-	valuesRef.current = values;
+	useEffect(() => {
+		valuesRef.current = values;
+	}, [values]);
 
 	const debouncedSubmit = useDebouncedSubmit(onSubmit);
 

--- a/storefront/src/checkout/hooks/useForm/useForm.ts
+++ b/storefront/src/checkout/hooks/useForm/useForm.ts
@@ -25,7 +25,15 @@ export const useForm = <TData extends FormDataBase>(formProps: FormProps<TData>)
 	);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const initialValuesRef = useRef(initialValues);
-	const [dirty, setDirty] = useState(initialDirty);
+
+	const computeDirty = useCallback(
+		(current: TData) => {
+			if (initialDirty) return true;
+			return JSON.stringify(current) !== JSON.stringify(initialValuesRef.current);
+		},
+		[initialDirty],
+	);
+	const [dirty, setDirty] = useState(() => computeDirty(initialValues));
 
 	// Keep a ref to latest values for use in submitForm callback
 	const valuesRef = useRef(values);
@@ -47,7 +55,7 @@ export const useForm = <TData extends FormDataBase>(formProps: FormProps<TData>)
 		<TFieldName extends string>(field: TFieldName, value: any) => {
 			setValuesState((prev) => {
 				const next = { ...prev, [field]: value };
-				setDirty(true);
+				setDirty(computeDirty(next));
 				if (validateOnChange && validationSchema) {
 					const formErrors = validationSchema(next);
 					setErrorsState(formErrors);
@@ -55,21 +63,21 @@ export const useForm = <TData extends FormDataBase>(formProps: FormProps<TData>)
 				return next;
 			});
 		},
-		[validateOnChange, validationSchema],
+		[validateOnChange, validationSchema, computeDirty],
 	);
 
 	const setValues = useCallback(
 		(newValues: Partial<TData>, shouldValidate?: boolean) => {
 			setValuesState((prev) => {
 				const next = { ...prev, ...newValues };
-				setDirty(true);
+				setDirty(computeDirty(next));
 				if (shouldValidate && validationSchema) {
 					setErrorsState(validationSchema(next));
 				}
 				return next;
 			});
 		},
-		[validationSchema],
+		[validationSchema, computeDirty],
 	);
 
 	const setErrors = useCallback((newErrors: FormErrors<TData>) => {
@@ -100,6 +108,9 @@ export const useForm = <TData extends FormDataBase>(formProps: FormProps<TData>)
 
 	const resetForm = useCallback((nextState?: { values?: TData }) => {
 		const resetValues = nextState?.values ?? initialValuesRef.current;
+		if (nextState?.values) {
+			initialValuesRef.current = nextState.values;
+		}
 		setValuesState(resetValues);
 		setErrorsState({});
 		setTouchedState({});
@@ -116,7 +127,7 @@ export const useForm = <TData extends FormDataBase>(formProps: FormProps<TData>)
 			const fieldValue = type === "checkbox" ? checked : value;
 			setValuesState((prev) => {
 				const next = { ...prev, [name]: fieldValue };
-				setDirty(true);
+				setDirty(computeDirty(next));
 				if (validateOnChange && validationSchema) {
 					const formErrors = validationSchema(next);
 					setErrorsState(formErrors);
@@ -124,7 +135,7 @@ export const useForm = <TData extends FormDataBase>(formProps: FormProps<TData>)
 				return next;
 			});
 		},
-		[validateOnChange, validationSchema],
+		[validateOnChange, validationSchema, computeDirty],
 	);
 
 	const handleBlur = useCallback(

--- a/storefront/src/checkout/hooks/useForm/useForm.ts
+++ b/storefront/src/checkout/hooks/useForm/useForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, createContext, useContext } from "react";
+import { useState, useCallback, useRef, useEffect, createContext, useContext } from "react";
 import {
 	type FormDataBase,
 	type FormProps,
@@ -37,7 +37,9 @@ export const useForm = <TData extends FormDataBase>(formProps: FormProps<TData>)
 
 	// Keep a ref to latest values for use in submitForm callback
 	const valuesRef = useRef(values);
-	valuesRef.current = values;
+	useEffect(() => {
+		valuesRef.current = values;
+	}, [values]);
 
 	const validateForm = useCallback(
 		(vals: TData): FormErrors<TData> => {

--- a/storefront/src/lib/fetch-retry.ts
+++ b/storefront/src/lib/fetch-retry.ts
@@ -15,19 +15,33 @@ interface RetryOptions {
 
 type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
-/** Wrap fetch with automatic retry for transient failures (network errors, 5xx). */
+/** Check if a GraphQL request body contains a mutation (not safe to retry). */
+function isMutation(init?: RequestInit): boolean {
+	if (!init?.body || typeof init.body !== "string") return false;
+	try {
+		const parsed = JSON.parse(init.body) as { query?: string };
+		return typeof parsed.query === "string" && parsed.query.trimStart().startsWith("mutation");
+	} catch {
+		return false;
+	}
+}
+
+/** Wrap fetch with automatic retry for transient failures (network errors, 5xx).
+ *  Mutations are never retried to prevent duplicate side effects. */
 export function withRetry(
 	baseFetch: FetchFn,
 	{ maxRetries = 2, baseDelay = 500 }: RetryOptions = {},
 ): FetchFn {
 	return async (input, init) => {
+		// Never retry mutations — they may have already been applied server-side
+		const effectiveRetries = isMutation(init) ? 0 : maxRetries;
 		let lastError: Error | null = null;
 
-		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		for (let attempt = 0; attempt <= effectiveRetries; attempt++) {
 			try {
 				const response = await baseFetch(input, init);
 
-				if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < maxRetries) {
+				if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < effectiveRetries) {
 					await sleep(baseDelay * Math.pow(2, attempt));
 					continue;
 				}
@@ -36,7 +50,7 @@ export function withRetry(
 			} catch (error) {
 				lastError = error instanceof Error ? error : new Error(String(error));
 
-				if (attempt < maxRetries) {
+				if (attempt < effectiveRetries) {
 					await sleep(baseDelay * Math.pow(2, attempt));
 					continue;
 				}

--- a/storefront/src/lib/graphql.ts
+++ b/storefront/src/lib/graphql.ts
@@ -44,7 +44,9 @@ export async function executeGraphQL<Result, Variables>(
 
 	const response = await requestQueue.enqueue(async () => {
 		if (withAuth) {
-			return (await getServerAuthClient()).fetchWithAuth(apiUrl, input);
+			const authClient = await getServerAuthClient();
+			const authFetch = withRetry(authClient.fetchWithAuth.bind(authClient));
+			return authFetch(apiUrl, input);
 		}
 		return resilientFetch(apiUrl, input);
 	});

--- a/storefront/src/lib/request-queue.ts
+++ b/storefront/src/lib/request-queue.ts
@@ -73,7 +73,10 @@ function sleep(ms: number): Promise<void> {
 }
 
 // Module-level singleton — shared across all server-side GraphQL calls
-const maxConcurrent = parseInt(process.env.SALEOR_MAX_CONCURRENT_REQUESTS || "3", 10);
-const minDelay = parseInt(process.env.SALEOR_MIN_REQUEST_DELAY_MS || "200", 10);
+const rawMaxConcurrent = parseInt(process.env.SALEOR_MAX_CONCURRENT_REQUESTS || "3", 10);
+const rawMinDelay = parseInt(process.env.SALEOR_MIN_REQUEST_DELAY_MS || "200", 10);
+
+const maxConcurrent = Number.isFinite(rawMaxConcurrent) && rawMaxConcurrent > 0 ? rawMaxConcurrent : 3;
+const minDelay = Number.isFinite(rawMinDelay) && rawMinDelay >= 0 ? rawMinDelay : 200;
 
 export const requestQueue = new RequestQueue(maxConcurrent, minDelay);


### PR DESCRIPTION
## Summary

Addresses all 22 Codex automated review concerns identified across PRs #50-#61. Changes span storefront, POS, buylist, and infrastructure.

### Storefront Account Pages (PR #58)
- Country dropdown now uses `Intl.DisplayNames` + `CountryCode` enum (not hardcoded)
- `LoginForm` passes `redirectTo` with current path on account pages
- `AddressCard` server actions wrapped in `useTransition`
- All server actions in `actions.ts` wrap `executeGraphQL` in try/catch

### Storefront Checkout Forms (PR #52)
- `useForm` dirty flag derived from value comparison via `computeDirty`
- `resetForm` updates `initialValuesRef` when values provided
- `partialSubmit` reads current values via `valuesRef` pattern (no stale closures)

### Storefront GraphQL Resilience (PR #54)
- `withRetry` now wraps authenticated fetch path too
- Request queue env parsing validates NaN/zero with safe defaults
- Mutations are never retried (prevents duplicate side effects)

### Storefront Caching (PR #53)
- Immutable cache rule scoped to `/_next/static/` paths only

### POS Customer Discounts (PR #58)
- `attachToTransaction` adds group discount to existing manual discount
- `detachFromTransaction` removes only group discount amount, preserves manual

### POS Offline (PR #51)
- Stock conflict query paginates beyond first 100 variants (MAX_PAGES=20 safety)
- `backupOfflineTransaction` uses create-first with conflict fallback

### Buylist (PR #58)
- `createAndPay` idempotency path returns consistent shape with `groupInfo`

## Verification

- Storefront: `tsc --noEmit` clean, 251/251 vitest tests pass
- POS: `tsc --noEmit` clean
- Buylist: `tsc --noEmit` clean

## Test plan

- [ ] Storefront checkout flow — verify form dirty state, validation, address auto-save
- [ ] Storefront account pages — verify login redirect, address CRUD with transitions
- [ ] POS customer discount attach/detach — verify manual discount preserved
- [ ] POS offline backup and stock conflict detection
- [ ] Buylist createAndPay idempotency path

🤖 Generated with [Claude Code](https://claude.com/claude-code)