### PR TITLE
feat: consolidate buylist + mtg-import into inventory-ops

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -121,7 +121,7 @@ jobs:
           SHA="${{ inputs.staging_sha }}"
           echo "Verifying images with SHA: ${SHA}"
 
-          SERVICES="storefront stripe-app inventory-ops-app buylist-app pos-app"
+          SERVICES="storefront stripe-app inventory-ops-app pos-app"
           ALL_EXIST=true
 
           for SERVICE in $SERVICES; do
@@ -326,7 +326,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [stripe-app, inventory-ops-app, buylist-app, pos-app]
+        service: [stripe-app, inventory-ops-app, pos-app]
       fail-fast: true
 
     steps:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -49,18 +49,16 @@ jobs:
       storefront: ${{ steps.filter.outputs.storefront }}
       stripe: ${{ steps.merge.outputs.stripe }}
       inventory-ops: ${{ steps.merge.outputs.inventory-ops }}
-      buylist: ${{ steps.merge.outputs.buylist }}
       pos: ${{ steps.merge.outputs.pos }}
-      mtg-import: ${{ steps.merge.outputs.mtg-import }}
       migrations: ${{ steps.merge.outputs.migrations }}
-      any_app: ${{ steps.merge.outputs.stripe == 'true' || steps.merge.outputs.inventory-ops == 'true' || steps.merge.outputs.buylist == 'true' || steps.merge.outputs.pos == 'true' || steps.merge.outputs.mtg-import == 'true' }}
+      any_app: ${{ steps.merge.outputs.stripe == 'true' || steps.merge.outputs.inventory-ops == 'true' || steps.merge.outputs.pos == 'true' }}
       any_changed: ${{ steps.check.outputs.any_changed }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
           fetch-depth: 2  # Only need HEAD~1 for change detection
 
@@ -83,18 +81,11 @@ jobs:
             inventory-ops:
               - 'saleor-apps/apps/inventory-ops/**'
               - 'saleor-apps/packages/**'
-            buylist:
-              - 'saleor-apps/apps/buylist/**'
-              - 'saleor-apps/packages/**'
             pos:
               - 'saleor-apps/apps/pos/**'
               - 'saleor-apps/packages/**'
-            mtg-import:
-              - 'saleor-apps/apps/mtg-import/**'
-              - 'saleor-apps/packages/**'
             migrations:
               - 'saleor-apps/apps/inventory-ops/prisma/**'
-              - 'saleor-apps/apps/mtg-import/prisma/**'
 
       # dorny/paths-filter can't see inside submodule content changes —
       # it only sees the pointer diff. This step inspects the actual files
@@ -109,9 +100,7 @@ jobs:
             echo "No submodule changes detected"
             echo "stripe=false" >> $GITHUB_OUTPUT
             echo "inventory-ops=false" >> $GITHUB_OUTPUT
-            echo "buylist=false" >> $GITHUB_OUTPUT
             echo "pos=false" >> $GITHUB_OUTPUT
-            echo "mtg-import=false" >> $GITHUB_OUTPUT
             echo "packages=false" >> $GITHUB_OUTPUT
             echo "migrations=false" >> $GITHUB_OUTPUT
             exit 0
@@ -139,15 +128,12 @@ jobs:
 
           echo "stripe=$(check_app apps/stripe)" >> $GITHUB_OUTPUT
           echo "inventory-ops=$(check_app apps/inventory-ops)" >> $GITHUB_OUTPUT
-          echo "buylist=$(check_app apps/buylist)" >> $GITHUB_OUTPUT
           echo "pos=$(check_app apps/pos)" >> $GITHUB_OUTPUT
-          echo "mtg-import=$(check_app apps/mtg-import)" >> $GITHUB_OUTPUT
           echo "packages=$(check_app packages)" >> $GITHUB_OUTPUT
 
           # Migration-specific detection (Prisma schema/migration files)
           INVOPS_PRISMA=$(check_app apps/inventory-ops/prisma)
-          MTGIMP_PRISMA=$(check_app apps/mtg-import/prisma)
-          if [[ "$INVOPS_PRISMA" == "true" ]] || [[ "$MTGIMP_PRISMA" == "true" ]]; then
+          if [[ "$INVOPS_PRISMA" == "true" ]]; then
             echo "migrations=true" >> $GITHUB_OUTPUT
           else
             echo "migrations=false" >> $GITHUB_OUTPUT
@@ -175,9 +161,7 @@ jobs:
 
           STRIPE=$(merge stripe "${{ steps.filter.outputs.stripe }}" "${{ steps.submodule.outputs.stripe }}" "$SUB_PKG")
           INVOPS=$(merge inventory-ops "${{ steps.filter.outputs.inventory-ops }}" "${{ steps.submodule.outputs.inventory-ops }}" "$SUB_PKG")
-          BUYLIST=$(merge buylist "${{ steps.filter.outputs.buylist }}" "${{ steps.submodule.outputs.buylist }}" "$SUB_PKG")
           POS=$(merge pos "${{ steps.filter.outputs.pos }}" "${{ steps.submodule.outputs.pos }}" "$SUB_PKG")
-          MTGIMP=$(merge mtg-import "${{ steps.filter.outputs.mtg-import }}" "${{ steps.submodule.outputs.mtg-import }}" "$SUB_PKG")
 
           # Migrations: dorny OR submodule detection
           DORNY_MIG="${{ steps.filter.outputs.migrations }}"
@@ -190,9 +174,7 @@ jobs:
 
           echo "stripe=$STRIPE" >> $GITHUB_OUTPUT
           echo "inventory-ops=$INVOPS" >> $GITHUB_OUTPUT
-          echo "buylist=$BUYLIST" >> $GITHUB_OUTPUT
           echo "pos=$POS" >> $GITHUB_OUTPUT
-          echo "mtg-import=$MTGIMP" >> $GITHUB_OUTPUT
           echo "migrations=$MIGRATIONS" >> $GITHUB_OUTPUT
 
           echo "## Change Detection Results" >> $GITHUB_STEP_SUMMARY
@@ -200,9 +182,7 @@ jobs:
           echo "|---------|-------|-----------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| stripe | ${{ steps.filter.outputs.stripe }} | ${{ steps.submodule.outputs.stripe }} | $STRIPE |" >> $GITHUB_STEP_SUMMARY
           echo "| inventory-ops | ${{ steps.filter.outputs.inventory-ops }} | ${{ steps.submodule.outputs.inventory-ops }} | $INVOPS |" >> $GITHUB_STEP_SUMMARY
-          echo "| buylist | ${{ steps.filter.outputs.buylist }} | ${{ steps.submodule.outputs.buylist }} | $BUYLIST |" >> $GITHUB_STEP_SUMMARY
           echo "| pos | ${{ steps.filter.outputs.pos }} | ${{ steps.submodule.outputs.pos }} | $POS |" >> $GITHUB_STEP_SUMMARY
-          echo "| mtg-import | ${{ steps.filter.outputs.mtg-import }} | ${{ steps.submodule.outputs.mtg-import }} | $MTGIMP |" >> $GITHUB_STEP_SUMMARY
           echo "| migrations | $DORNY_MIG | $SUB_MIG | $MIGRATIONS |" >> $GITHUB_STEP_SUMMARY
 
       - name: Check if any service changed
@@ -212,9 +192,7 @@ jobs:
              [[ "${{ steps.filter.outputs.storefront }}" == "true" ]] || \
              [[ "${{ steps.merge.outputs.stripe }}" == "true" ]] || \
              [[ "${{ steps.merge.outputs.inventory-ops }}" == "true" ]] || \
-             [[ "${{ steps.merge.outputs.buylist }}" == "true" ]] || \
-             [[ "${{ steps.merge.outputs.pos }}" == "true" ]] || \
-             [[ "${{ steps.merge.outputs.mtg-import }}" == "true" ]]; then
+             [[ "${{ steps.merge.outputs.pos }}" == "true" ]]; then
             echo "any_changed=true" >> $GITHUB_OUTPUT
           else
             echo "any_changed=false" >> $GITHUB_OUTPUT
@@ -282,13 +260,6 @@ jobs:
             change_key: inventory-ops
             build_args_extra: |
               BASE_PATH=/apps/inventory
-          - service: buylist-app
-            image_name: saleor-platform/buylist-app
-            context: ./saleor-apps
-            dockerfile: ./saleor-apps/apps/buylist/Dockerfile
-            change_key: buylist
-            build_args_extra: |
-              BASE_PATH=/apps/buylist
           - service: pos-app
             image_name: saleor-platform/pos-app
             context: ./saleor-apps
@@ -296,13 +267,6 @@ jobs:
             change_key: pos
             build_args_extra: |
               BASE_PATH=/apps/pos
-          - service: mtg-import-app
-            image_name: saleor-platform/mtg-import-app
-            context: ./saleor-apps
-            dockerfile: ./saleor-apps/apps/mtg-import/Dockerfile
-            change_key: mtg-import
-            build_args_extra: |
-              BASE_PATH=/apps/mtg-import
       fail-fast: false
 
     outputs:
@@ -326,7 +290,7 @@ jobs:
         if: steps.should-build.outputs.build == 'true'
         uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
       - name: Configure AWS credentials
@@ -473,24 +437,6 @@ jobs:
             exit 1
           fi
 
-          echo "::group::Prisma migrations (mtg-import)"
-          if ./scripts/deploy/aws/run-migrations.sh staging prisma mtg-import; then
-            echo "✅ Prisma mtg-import migrations succeeded"
-            MIGRATION_STATUS="${MIGRATION_STATUS},prisma-mtg-import:success"
-          else
-            echo "❌ Prisma mtg-import migrations FAILED"
-            MIGRATION_STATUS="${MIGRATION_STATUS},prisma-mtg-import:FAILED"
-            FAILED=true
-          fi
-          echo "::endgroup::"
-
-          if [[ "$FAILED" == "true" ]]; then
-            echo "::error::Prisma mtg-import migrations failed"
-            echo "::warning::PARTIAL MIGRATION STATE: ${MIGRATION_STATUS}"
-            echo "::warning::Django + inventory-ops Prisma succeeded, but mtg-import Prisma failed."
-            exit 1
-          fi
-
           echo "✅ All migrations succeeded: ${MIGRATION_STATUS}"
         env:
           SHA: ${{ needs.validate.outputs.sha_short }}
@@ -587,12 +533,8 @@ jobs:
             service: stripe
           - app: inventory-ops
             service: inventory-ops
-          - app: buylist
-            service: buylist
           - app: pos
             service: pos
-          - app: mtg-import
-            service: mtg-import
       fail-fast: false
 
     steps:
@@ -712,7 +654,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Apps Verified" >> $GITHUB_STEP_SUMMARY
           echo "- Stripe: ${{ vars.STAGING_APPS_URL }}/apps/stripe" >> $GITHUB_STEP_SUMMARY
-          echo "- Inventory: ${{ vars.STAGING_APPS_URL }}/apps/inventory" >> $GITHUB_STEP_SUMMARY
-          echo "- Buylist: ${{ vars.STAGING_APPS_URL }}/apps/buylist" >> $GITHUB_STEP_SUMMARY
+          echo "- Inventory Ops: ${{ vars.STAGING_APPS_URL }}/apps/inventory" >> $GITHUB_STEP_SUMMARY
           echo "- POS: ${{ vars.STAGING_APPS_URL }}/apps/pos" >> $GITHUB_STEP_SUMMARY
-          echo "- MTG Import: ${{ vars.STAGING_APPS_URL }}/apps/mtg-import" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -109,9 +109,9 @@ jobs:
           echo "Submodule diff detected, checking which apps changed..."
 
           # Extract changed file paths from the submodule diff
-          # Lines look like: "diff --git a/saleor-apps/apps/mtg-import/... b/saleor-apps/apps/mtg-import/..."
+          # Lines look like: "diff --git a/saleor-apps/apps/inventory-ops/... b/saleor-apps/apps/inventory-ops/..."
           # The saleor-apps/ prefix (submodule mount point) must be stripped so
-          # check_app can match against bare paths like "apps/mtg-import/".
+          # check_app can match against bare paths like "apps/inventory-ops/".
           CHANGED_FILES=$(echo "$DIFF" | grep '^diff --git' | sed 's|diff --git a/||; s| b/.*||; s|^saleor-apps/||')
           echo "Changed files in submodule:"
           echo "$CHANGED_FILES"

--- a/.github/workflows/terraform-plan-on-pr.yml
+++ b/.github/workflows/terraform-plan-on-pr.yml
@@ -76,7 +76,7 @@ jobs:
       # --- trivy IaC scan ---
       - name: Run Trivy IaC scan
         id: trivy
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: config
           scan-ref: infra/terraform

--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -18,7 +18,6 @@ jobs:
       storefront: ${{ steps.filter.outputs.storefront }}
       apps: ${{ steps.merge.outputs.apps }}
       inventory-ops: ${{ steps.merge.outputs.inventory-ops }}
-      buylist: ${{ steps.merge.outputs.buylist }}
       pos: ${{ steps.merge.outputs.pos }}
       stripe: ${{ steps.merge.outputs.stripe }}
       migrations: ${{ steps.merge.outputs.migrations }}
@@ -30,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
           fetch-depth: 2
 
@@ -55,15 +54,11 @@ jobs:
             inventory-ops:
               - 'saleor-apps/apps/inventory-ops/**'
               - 'saleor-apps/packages/**'
-            buylist:
-              - 'saleor-apps/apps/buylist/**'
-              - 'saleor-apps/packages/**'
             pos:
               - 'saleor-apps/apps/pos/**'
               - 'saleor-apps/packages/**'
             migrations:
               - 'saleor-apps/apps/inventory-ops/prisma/**'
-              - 'saleor-apps/apps/mtg-import/prisma/**'
             terraform:
               - 'infra/terraform/**'
             compose:
@@ -83,7 +78,6 @@ jobs:
             echo "apps=false" >> $GITHUB_OUTPUT
             echo "stripe=false" >> $GITHUB_OUTPUT
             echo "inventory-ops=false" >> $GITHUB_OUTPUT
-            echo "buylist=false" >> $GITHUB_OUTPUT
             echo "pos=false" >> $GITHUB_OUTPUT
             echo "packages=false" >> $GITHUB_OUTPUT
             echo "migrations=false" >> $GITHUB_OUTPUT
@@ -107,13 +101,11 @@ jobs:
           echo "apps=true" >> $GITHUB_OUTPUT
           echo "stripe=$(check_app apps/stripe)" >> $GITHUB_OUTPUT
           echo "inventory-ops=$(check_app apps/inventory-ops)" >> $GITHUB_OUTPUT
-          echo "buylist=$(check_app apps/buylist)" >> $GITHUB_OUTPUT
           echo "pos=$(check_app apps/pos)" >> $GITHUB_OUTPUT
           echo "packages=$(check_app packages)" >> $GITHUB_OUTPUT
 
           INVOPS_PRISMA=$(check_app apps/inventory-ops/prisma)
-          MTGIMP_PRISMA=$(check_app apps/mtg-import/prisma)
-          if [[ "$INVOPS_PRISMA" == "true" ]] || [[ "$MTGIMP_PRISMA" == "true" ]]; then
+          if [[ "$INVOPS_PRISMA" == "true" ]]; then
             echo "migrations=true" >> $GITHUB_OUTPUT
           else
             echo "migrations=false" >> $GITHUB_OUTPUT
@@ -139,7 +131,6 @@ jobs:
           APPS=$(merge "${{ steps.filter.outputs.apps }}" "$SUB_APPS" "false")
           STRIPE=$(merge "${{ steps.filter.outputs.stripe }}" "${{ steps.submodule.outputs.stripe }}" "$SUB_PKG")
           INVOPS=$(merge "${{ steps.filter.outputs.inventory-ops }}" "${{ steps.submodule.outputs.inventory-ops }}" "$SUB_PKG")
-          BUYLIST=$(merge "${{ steps.filter.outputs.buylist }}" "${{ steps.submodule.outputs.buylist }}" "$SUB_PKG")
           POS=$(merge "${{ steps.filter.outputs.pos }}" "${{ steps.submodule.outputs.pos }}" "$SUB_PKG")
 
           DORNY_MIG="${{ steps.filter.outputs.migrations }}"
@@ -153,7 +144,6 @@ jobs:
           echo "apps=$APPS" >> $GITHUB_OUTPUT
           echo "stripe=$STRIPE" >> $GITHUB_OUTPUT
           echo "inventory-ops=$INVOPS" >> $GITHUB_OUTPUT
-          echo "buylist=$BUYLIST" >> $GITHUB_OUTPUT
           echo "pos=$POS" >> $GITHUB_OUTPUT
           echo "migrations=$MIGRATIONS" >> $GITHUB_OUTPUT
 
@@ -164,7 +154,6 @@ jobs:
           echo "| apps (any) | ${{ steps.filter.outputs.apps }} | $SUB_APPS | $APPS |" >> $GITHUB_STEP_SUMMARY
           echo "| stripe | ${{ steps.filter.outputs.stripe }} | ${{ steps.submodule.outputs.stripe }} | $STRIPE |" >> $GITHUB_STEP_SUMMARY
           echo "| inventory-ops | ${{ steps.filter.outputs.inventory-ops }} | ${{ steps.submodule.outputs.inventory-ops }} | $INVOPS |" >> $GITHUB_STEP_SUMMARY
-          echo "| buylist | ${{ steps.filter.outputs.buylist }} | ${{ steps.submodule.outputs.buylist }} | $BUYLIST |" >> $GITHUB_STEP_SUMMARY
           echo "| pos | ${{ steps.filter.outputs.pos }} | ${{ steps.submodule.outputs.pos }} | $POS |" >> $GITHUB_STEP_SUMMARY
           echo "| migrations | $DORNY_MIG | $SUB_MIG | $MIGRATIONS |" >> $GITHUB_STEP_SUMMARY
           echo "| terraform | ${{ steps.filter.outputs.terraform }} | - | ${{ steps.filter.outputs.terraform }} |" >> $GITHUB_STEP_SUMMARY
@@ -175,7 +164,6 @@ jobs:
           if [[ "${{ steps.filter.outputs.storefront }}" == "true" ]] || \
              [[ "${{ steps.merge.outputs.stripe }}" == "true" ]] || \
              [[ "${{ steps.merge.outputs.inventory-ops }}" == "true" ]] || \
-             [[ "${{ steps.merge.outputs.buylist }}" == "true" ]] || \
              [[ "${{ steps.merge.outputs.pos }}" == "true" ]]; then
             echo "any_build=true" >> $GITHUB_OUTPUT
           else
@@ -239,7 +227,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
       - name: Setup pnpm
@@ -261,7 +249,7 @@ jobs:
         run: |
           # Only lint our custom apps, not upstream Saleor apps
           # Upstream apps (avatax, cms, klaviyo, etc.) have pre-existing lint issues
-          pnpm turbo run lint --filter=saleor-app-inventory-ops --filter=saleor-app-buylist --filter=saleor-app-pos
+          pnpm turbo run lint --filter=saleor-app-inventory-ops --filter=saleor-app-pos
 
       # Type check (tsc --noEmit) skipped for custom apps
       # Source code compiles clean — remaining errors are in test files only:
@@ -289,7 +277,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
       - name: Setup pnpm
@@ -360,11 +348,6 @@ jobs:
             dockerfile: ./saleor-apps/apps/inventory-ops/Dockerfile
             change_key: inventory-ops
             build_args: ""
-          - service: buylist
-            context: ./saleor-apps
-            dockerfile: ./saleor-apps/apps/buylist/Dockerfile
-            change_key: buylist
-            build_args: ""
           - service: pos
             context: ./saleor-apps
             dockerfile: ./saleor-apps/apps/pos/Dockerfile
@@ -394,7 +377,7 @@ jobs:
         if: steps.should-build.outputs.build == 'true'
         uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -424,7 +407,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
       - name: Set up Docker Buildx
@@ -469,7 +452,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive  # Nested submodules: pos, inventory-ops, buylist inside saleor-apps
+          submodules: recursive  # Nested submodules: pos, inventory-ops inside saleor-apps
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
       - name: Set up environment
@@ -481,9 +464,7 @@ jobs:
           POSTGRES_PASSWORD=saleor
           STRIPE_APP_SECRET_KEY=ci-stripe-key
           INVENTORY_OPS_SECRET_KEY=ci-inventory-key
-          BUYLIST_SECRET_KEY=ci-buylist-key
           POS_SECRET_KEY=ci-pos-key
-          MTG_IMPORT_SECRET_KEY=ci-mtg-import-key
           INVENTORY_DATABASE_URL=postgresql://inventory:inventory@inventory-ops-db:5432/inventory_ops
           INVENTORY_POSTGRES_USER=inventory
           INVENTORY_POSTGRES_PASSWORD=inventory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - SECRET_KEY=${SECRET_KEY:?SECRET_KEY is required}
       - DATABASE_URL=postgres://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db/saleor
       - DASHBOARD_URL=http://localhost:9000/
-      - ALLOWED_HOSTS=localhost,127.0.0.1,api,stripe-app,inventory-ops-app,buylist-app,pos-app,mtg-import-app,host.docker.internal
+      - ALLOWED_HOSTS=localhost,127.0.0.1,api,stripe-app,inventory-ops-app,pos-app,host.docker.internal
       - HTTP_IP_FILTER_ENABLED=False
       - RSA_PRIVATE_KEY=${RSA_PRIVATE_KEY:-}
       - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS:-}
@@ -239,37 +239,6 @@ services:
       - ALLOWED_DOMAIN_PATTERN=.*
       - LOGLEVEL=INFO
 
-  # Buylist App - shares inventory-ops database
-  buylist-app:
-    build:
-      context: ./saleor-apps
-      dockerfile: apps/buylist/Dockerfile
-    ports:
-      - 3003:3003
-    restart: unless-stopped
-    networks:
-      - saleor-backend-tier
-    extra_hosts:
-      - "localhost:host-gateway"
-      - "host.docker.internal:host-gateway"
-    depends_on:
-      - api
-      - inventory-ops-db
-    volumes:
-      - buylist-apl:/app/apps/buylist/data
-    environment:
-      - SECRET_KEY=${BUYLIST_SECRET_KEY:?BUYLIST_SECRET_KEY is required}
-      - DATABASE_URL=${INVENTORY_DATABASE_URL:?INVENTORY_DATABASE_URL is required}
-      - ALLOWED_DOMAIN_PATTERN=/.*/
-      - APP_IFRAME_BASE_URL=http://localhost:3003
-      - APP_API_BASE_URL=http://buylist-app:3003
-      - APP_LOG_LEVEL=debug
-      - DEFAULT_CURRENCY=USD
-      - DEFAULT_CHANNEL_SLUG=webstore
-      - MEILISEARCH_URL=http://meilisearch:7700
-      - SCRYFALL_API_BASE_URL=https://api.scryfall.com
-      - SCRYFALL_RATE_LIMIT_MS=100
-
   # POS App - Point of Sale for in-store transactions
   pos-app:
     build:
@@ -300,36 +269,6 @@ services:
       # Stripe Terminal settings (Phase 2)
       # - STRIPE_SECRET_KEY=sk_test_...
       # - STRIPE_TERMINAL_LOCATION_ID=tml_...
-
-  # MTG Import App - bulk card import from Scryfall
-  mtg-import-app:
-    build:
-      context: ./saleor-apps
-      dockerfile: apps/mtg-import/Dockerfile
-    ports:
-      - 3005:3005
-    restart: unless-stopped
-    networks:
-      - saleor-backend-tier
-    extra_hosts:
-      - "localhost:host-gateway"
-      - "host.docker.internal:host-gateway"
-    depends_on:
-      - api
-      - inventory-ops-db
-    volumes:
-      - mtg-import-apl:/app/apps/mtg-import/data
-    environment:
-      - SECRET_KEY=${MTG_IMPORT_SECRET_KEY:?MTG_IMPORT_SECRET_KEY is required}
-      - DATABASE_URL=${INVENTORY_DATABASE_URL:?INVENTORY_DATABASE_URL is required}
-      - ALLOWED_DOMAIN_PATTERN=/.*/
-      - APP_IFRAME_BASE_URL=http://localhost:3005
-      - APP_API_BASE_URL=http://mtg-import-app:3005
-      - APP_LOG_LEVEL=debug
-      - DEFAULT_CURRENCY=USD
-      - SCRYFALL_API_BASE_URL=https://api.scryfall.com
-      - SCRYFALL_RATE_LIMIT_MS=100
-      - SCRYFALL_CONTACT_EMAIL=${SCRYFALL_CONTACT_EMAIL:-dev@localhost.local}
 
   # Meilisearch - fast search engine for singles-builder
   meilisearch:
@@ -386,11 +325,7 @@ volumes:
     driver: local
   inventory-ops-apl:
     driver: local
-  buylist-apl:
-    driver: local
   pos-apl:
-    driver: local
-  mtg-import-apl:
     driver: local
   meilisearch-data:
     driver: local

--- a/infra/terraform/environments/staging.tfvars
+++ b/infra/terraform/environments/staging.tfvars
@@ -123,7 +123,6 @@ saleor_dashboard_image = "ghcr.io/saleor/saleor-dashboard:3.22.34"
 
 # Saleor Apps image tags
 stripe_app_image_tag     = "document-polyfill-v1"
-mtg_import_app_image_tag = "staging-latest"
 
 # GitHub
 github_org    = "michael-a-bean"

--- a/infra/terraform/environments/staging.tfvars
+++ b/infra/terraform/environments/staging.tfvars
@@ -122,7 +122,7 @@ saleor_api_image       = "ghcr.io/saleor/saleor:3.22.39"
 saleor_dashboard_image = "ghcr.io/saleor/saleor-dashboard:3.22.34"
 
 # Saleor Apps image tags
-stripe_app_image_tag     = "document-polyfill-v1"
+stripe_app_image_tag = "document-polyfill-v1"
 
 # GitHub
 github_org    = "michael-a-bean"

--- a/infra/terraform/imports.tf
+++ b/infra/terraform/imports.tf
@@ -22,11 +22,6 @@ import {
 }
 
 import {
-  to = module.ecr.aws_ecr_repository.repos["buylist-app"]
-  id = "saleor-platform/buylist-app"
-}
-
-import {
   to = module.ecr.aws_ecr_repository.repos["pos-app"]
   id = "saleor-platform/pos-app"
 }
@@ -75,11 +70,6 @@ import {
 }
 
 import {
-  to = module.alb.aws_lb_target_group.buylist_app
-  id = "arn:aws:elasticloadbalancing:us-west-1:546464732019:targetgroup/saleor-platform-staging-buylist/2d69fd6447cdc796"
-}
-
-import {
   to = module.alb.aws_lb_target_group.pos_app
   id = "arn:aws:elasticloadbalancing:us-west-1:546464732019:targetgroup/saleor-platform-staging-pos/89fd87464e2f1975"
 }
@@ -91,7 +81,7 @@ import {
 # HTTPS mode uses host-based routing on the HTTPS listener instead.
 # Kept as comments for historical reference.
 # Previously imported: api_http, dashboard_http, stripe_app_http,
-#   inventory_ops_app_http, buylist_app_http, pos_app_http
+#   inventory_ops_app_http, pos_app_http
 
 # =============================================================================
 # CloudFront - Added 2026-01-27 after drift analysis
@@ -369,11 +359,6 @@ import {
 }
 
 import {
-  to = module.ecs.aws_cloudwatch_log_group.services["buylist-app"]
-  id = "/ecs/saleor-platform-staging/buylist-app"
-}
-
-import {
   to = module.ecs.aws_cloudwatch_log_group.services["pos-app"]
   id = "/ecs/saleor-platform-staging/pos-app"
 }
@@ -419,11 +404,6 @@ import {
 import {
   to = module.ecs.aws_ecs_service.apps["inventory-ops"]
   id = "saleor-platform-staging/inventory-ops"
-}
-
-import {
-  to = module.ecs.aws_ecs_service.apps["buylist"]
-  id = "saleor-platform-staging/buylist"
 }
 
 import {
@@ -550,24 +530,6 @@ import {
 }
 
 
-# MTG Import resources (created before Terraform adoption)
-import {
-  to = module.ecr.aws_ecr_repository.repos["mtg-import-app"]
-  id = "saleor-platform/mtg-import-app"
-}
-
-import {
-  to = module.ecs.aws_cloudwatch_log_group.services["mtg-import-app"]
-  id = "/ecs/saleor-platform-staging/mtg-import-app"
-}
-
-import {
-  to = module.alb.aws_lb_target_group.mtg_import_app
-  id = "arn:aws:elasticloadbalancing:us-west-1:546464732019:targetgroup/saleor-platform-staging-mtg-imp/a7cee7de4721f945"
-}
-
-# mtg_import_app_http[0] removed 2026-02-14 — destroyed with enable_https=true
-
 # =============================================================================
 # Route53 Records (created manually, importing into state 2026-03-06)
 # =============================================================================
@@ -625,18 +587,8 @@ import {
 }
 
 import {
-  to = module.alb.aws_lb_listener_rule.buylist_app[0]
-  id = "arn:aws:elasticloadbalancing:us-west-1:546464732019:listener-rule/app/saleor-platform-staging-alb/db6a77fe4c4f68d7/11f61245eba8645a/de6a0928cd4e6fb8"
-}
-
-import {
   to = module.alb.aws_lb_listener_rule.pos_app[0]
   id = "arn:aws:elasticloadbalancing:us-west-1:546464732019:listener-rule/app/saleor-platform-staging-alb/db6a77fe4c4f68d7/11f61245eba8645a/dc7830b19d5e064c"
-}
-
-import {
-  to = module.alb.aws_lb_listener_rule.mtg_import_app[0]
-  id = "arn:aws:elasticloadbalancing:us-west-1:546464732019:listener-rule/app/saleor-platform-staging-alb/db6a77fe4c4f68d7/11f61245eba8645a/9537529efefe7bd4"
 }
 
 import {
@@ -683,18 +635,8 @@ import {
 }
 
 import {
-  to = module.ecs.aws_appautoscaling_target.apps["buylist"]
-  id = "ecs/service/saleor-platform-staging/buylist/ecs:service:DesiredCount"
-}
-
-import {
   to = module.ecs.aws_appautoscaling_target.apps["pos"]
   id = "ecs/service/saleor-platform-staging/pos/ecs:service:DesiredCount"
-}
-
-import {
-  to = module.ecs.aws_appautoscaling_target.apps["mtg-import"]
-  id = "ecs/service/saleor-platform-staging/mtg-import/ecs:service:DesiredCount"
 }
 
 # =============================================================================
@@ -704,14 +646,6 @@ import {
   to = module.secrets.aws_ssm_parameter.inventory_cron_secret
   id = "/saleor/staging/apps/inventory-ops/CRON_SECRET"
 }
-
-import {
-  to = module.ecs.aws_ecs_task_definition.apps["mtg-import"]
-  id = "arn:aws:ecs:us-west-1:546464732019:task-definition/saleor-platform-staging-mtg-import:8"
-}
-
-# ECS service imported via CLI (TF 1.5 import blocks don't support for_each service resources)
-# terraform import 'module.ecs.aws_ecs_service.apps["mtg-import"]' 'saleor-platform-staging/mtg-import'
 
 # Application Auto Scaling Targets — originally added 2026-02-21
 # Import blocks removed 2026-02-23: they errored with "does not exist in
@@ -728,6 +662,4 @@ import {
 #   - module.ecs.aws_appautoscaling_target.dashboard[0]
 #   - module.ecs.aws_appautoscaling_target.apps["stripe"]
 #   - module.ecs.aws_appautoscaling_target.apps["inventory-ops"]
-#   - module.ecs.aws_appautoscaling_target.apps["buylist"]
 #   - module.ecs.aws_appautoscaling_target.apps["pos"]
-#   - module.ecs.aws_appautoscaling_target.apps["mtg-import"]

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -283,7 +283,7 @@ module "grafana_dashboards" {
   ecs_cluster_name = local.name_prefix
   ecs_service_names = concat(
     ["api", "worker", "beat", "storefront", "dashboard"],
-    var.apps_enabled ? ["stripe", "inventory-ops", "buylist", "pos", "mtg-import"] : [],
+    var.apps_enabled ? ["stripe", "inventory-ops", "pos"] : [],
     var.meilisearch_enabled ? ["meilisearch"] : []
   )
 
@@ -485,7 +485,7 @@ module "ecs" {
     inventory-ops = {
       port             = 3002
       cpu              = 256
-      memory           = 512
+      memory           = 1024  # Bumped: now handles inventory-ops + buylist + mtg-import workloads
       base_path        = "/apps/inventory"
       image            = "${module.ecr.inventory_ops_app_repository_url}:${var.inventory_ops_app_image_tag}"
       target_group_arn = module.alb.inventory_ops_app_target_group_arn
@@ -508,28 +508,13 @@ module "ecs" {
         ] : []
       )
       environment = {
-        APL             = "redis"
-        REDIS_URL       = module.elasticache.cache_url
-        MEILISEARCH_URL = var.meilisearch_enabled ? module.meilisearch[0].service_url : "http://meilisearch.${local.name_prefix}.local:7700"
-      }
-    }
-
-    buylist = {
-      port             = 3003
-      cpu              = 256
-      memory           = 512
-      base_path        = "/apps/buylist"
-      image            = "${module.ecr.buylist_app_repository_url}:${var.buylist_app_image_tag}"
-      target_group_arn = module.alb.buylist_app_target_group_arn
-      secrets = [
-        {
-          name      = "DATABASE_URL"
-          valueFrom = "/saleor/${var.environment}/apps/inventory-ops/DATABASE_URL"
-        }
-      ]
-      environment = {
-        APL       = "redis"
-        REDIS_URL = module.elasticache.cache_url
+        APL                = "redis"
+        REDIS_URL          = module.elasticache.cache_url
+        MEILISEARCH_URL    = var.meilisearch_enabled ? module.meilisearch[0].service_url : "http://meilisearch.${local.name_prefix}.local:7700"
+        SCRYFALL_CACHE_DIR = "/tmp/scryfall-cache"
+        DEFAULT_CURRENCY   = "USD"
+        IMPORT_BATCH_SIZE  = "50"
+        IMPORT_CONCURRENCY = "5"
       }
     }
 
@@ -552,29 +537,6 @@ module "ecs" {
       }
     }
 
-    mtg-import = {
-      port             = 3005
-      cpu              = 256  # Right-sized: 2.8% avg CPU, I/O-bound workload
-      memory           = 1024 # Right-sized: 39% peak of 2048 = ~800 MB fits in 1024
-      desired_count    = 1    # Always-on service for catalog management
-      base_path        = "/apps/mtg-import"
-      image            = "${module.ecr.mtg_import_app_repository_url}:${var.mtg_import_app_image_tag}"
-      target_group_arn = module.alb.mtg_import_app_target_group_arn
-      secrets = [
-        {
-          name      = "DATABASE_URL"
-          valueFrom = "/saleor/${var.environment}/apps/inventory-ops/DATABASE_URL"
-        }
-      ]
-      environment = {
-        APL                = "redis"
-        REDIS_URL          = module.elasticache.cache_url
-        SCRYFALL_CACHE_DIR = "/tmp/scryfall-cache"
-        DEFAULT_CURRENCY   = "USD"
-        IMPORT_BATCH_SIZE  = "50" # Doubled from default 25; RDS db.t3.medium handles larger batches
-        IMPORT_CONCURRENCY = "5"  # Up from default 3; more DB RAM = more parallel writes
-      }
-    }
   }
 }
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -485,7 +485,7 @@ module "ecs" {
     inventory-ops = {
       port             = 3002
       cpu              = 256
-      memory           = 1024  # Bumped: now handles inventory-ops + buylist + mtg-import workloads
+      memory           = 1024 # Bumped: now handles inventory-ops + buylist + mtg-import workloads
       base_path        = "/apps/inventory"
       image            = "${module.ecr.inventory_ops_app_repository_url}:${var.inventory_ops_app_image_tag}"
       target_group_arn = module.alb.inventory_ops_app_target_group_arn

--- a/infra/terraform/modules/alb/main.tf
+++ b/infra/terraform/modules/alb/main.tf
@@ -262,7 +262,7 @@ resource "aws_lb_target_group" "dashboard" {
 }
 
 # =============================================================================
-# Apps Target Groups (stripe, inventory-ops, buylist, pos)
+# Apps Target Groups (stripe, inventory-ops, pos)
 # NOTE: Health check paths include basePath since ALB preserves full request path
 # =============================================================================
 
@@ -312,29 +312,6 @@ resource "aws_lb_target_group" "inventory_ops_app" {
   }
 }
 
-resource "aws_lb_target_group" "buylist_app" {
-  name        = "${local.name_prefix}-buylist"
-  port        = 3003
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
-  target_type = "ip"
-
-  health_check {
-    enabled             = true
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
-    timeout             = 5
-    interval            = 30
-    path                = "/apps/buylist/api/health"
-    matcher             = "200"
-  }
-
-  tags = {
-    Name    = "${local.name_prefix}-buylist-app"
-    Service = "buylist-app"
-  }
-}
-
 resource "aws_lb_target_group" "pos_app" {
   name        = "${local.name_prefix}-pos"
   port        = 3004
@@ -355,29 +332,6 @@ resource "aws_lb_target_group" "pos_app" {
   tags = {
     Name    = "${local.name_prefix}-pos-app"
     Service = "pos-app"
-  }
-}
-
-resource "aws_lb_target_group" "mtg_import_app" {
-  name        = "${local.name_prefix}-mtg-imp"
-  port        = 3005
-  protocol    = "HTTP"
-  vpc_id      = var.vpc_id
-  target_type = "ip"
-
-  health_check {
-    enabled             = true
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
-    timeout             = 5
-    interval            = 30
-    path                = "/apps/mtg-import/api/health"
-    matcher             = "200"
-  }
-
-  tags = {
-    Name    = "${local.name_prefix}-mtg-import-app"
-    Service = "mtg-import-app"
   }
 }
 
@@ -524,32 +478,6 @@ resource "aws_lb_listener_rule" "inventory_ops_app" {
   }
 }
 
-# Buylist app routing: apps.{domain}/apps/buylist/*
-# Path must match the app's BASE_PATH=/apps/buylist set at Docker build time
-resource "aws_lb_listener_rule" "buylist_app" {
-  count = var.enable_https ? 1 : 0
-
-  listener_arn = aws_lb_listener.https[0].arn
-  priority     = 220
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.buylist_app.arn
-  }
-
-  condition {
-    host_header {
-      values = ["apps.${var.domain_name}"]
-    }
-  }
-
-  condition {
-    path_pattern {
-      values = ["/apps/buylist/*", "/apps/buylist"]
-    }
-  }
-}
-
 # POS app routing: apps.{domain}/apps/pos/*
 # Path must match the app's BASE_PATH=/apps/pos set at Docker build time
 resource "aws_lb_listener_rule" "pos_app" {
@@ -572,32 +500,6 @@ resource "aws_lb_listener_rule" "pos_app" {
   condition {
     path_pattern {
       values = ["/apps/pos/*", "/apps/pos"]
-    }
-  }
-}
-
-# MTG Import app routing: apps.{domain}/apps/mtg-import/*
-# Path must match the app's BASE_PATH=/apps/mtg-import set at Docker build time
-resource "aws_lb_listener_rule" "mtg_import_app" {
-  count = var.enable_https ? 1 : 0
-
-  listener_arn = aws_lb_listener.https[0].arn
-  priority     = 240
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.mtg_import_app.arn
-  }
-
-  condition {
-    host_header {
-      values = ["apps.${var.domain_name}"]
-    }
-  }
-
-  condition {
-    path_pattern {
-      values = ["/apps/mtg-import/*", "/apps/mtg-import"]
     }
   }
 }
@@ -709,25 +611,6 @@ resource "aws_lb_listener_rule" "inventory_ops_app_http" {
   }
 }
 
-# Buylist app routing on HTTP: /apps/buylist/*
-resource "aws_lb_listener_rule" "buylist_app_http" {
-  count = !var.enable_https ? 1 : 0
-
-  listener_arn = aws_lb_listener.http.arn
-  priority     = 220
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.buylist_app.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["/apps/buylist/*", "/apps/buylist"]
-    }
-  }
-}
-
 # POS app routing on HTTP: /apps/pos/*
 resource "aws_lb_listener_rule" "pos_app_http" {
   count = !var.enable_https ? 1 : 0
@@ -747,21 +630,3 @@ resource "aws_lb_listener_rule" "pos_app_http" {
   }
 }
 
-# MTG Import app routing on HTTP: /apps/mtg-import/*
-resource "aws_lb_listener_rule" "mtg_import_app_http" {
-  count = !var.enable_https ? 1 : 0
-
-  listener_arn = aws_lb_listener.http.arn
-  priority     = 240
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.mtg_import_app.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["/apps/mtg-import/*", "/apps/mtg-import"]
-    }
-  }
-}

--- a/infra/terraform/modules/alb/outputs.tf
+++ b/infra/terraform/modules/alb/outputs.tf
@@ -61,19 +61,9 @@ output "inventory_ops_app_target_group_arn" {
   value       = aws_lb_target_group.inventory_ops_app.arn
 }
 
-output "buylist_app_target_group_arn" {
-  description = "ARN of Buylist app target group"
-  value       = aws_lb_target_group.buylist_app.arn
-}
-
 output "pos_app_target_group_arn" {
   description = "ARN of POS app target group"
   value       = aws_lb_target_group.pos_app.arn
-}
-
-output "mtg_import_app_target_group_arn" {
-  description = "ARN of MTG Import app target group"
-  value       = aws_lb_target_group.mtg_import_app.arn
 }
 
 output "alb_arn_suffix" {

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -25,19 +25,9 @@ output "inventory_ops_app_repository_url" {
   value       = aws_ecr_repository.repos["inventory-ops-app"].repository_url
 }
 
-output "buylist_app_repository_url" {
-  description = "URL of buylist-app repository"
-  value       = aws_ecr_repository.repos["buylist-app"].repository_url
-}
-
 output "pos_app_repository_url" {
   description = "URL of pos-app repository"
   value       = aws_ecr_repository.repos["pos-app"].repository_url
-}
-
-output "mtg_import_app_repository_url" {
-  description = "URL of mtg-import-app repository"
-  value       = aws_ecr_repository.repos["mtg-import-app"].repository_url
 }
 
 

--- a/infra/terraform/modules/ecs/main.tf
+++ b/infra/terraform/modules/ecs/main.tf
@@ -41,7 +41,7 @@ resource "aws_ecs_cluster_capacity_providers" "main" {
 resource "aws_cloudwatch_log_group" "services" {
   for_each = toset([
     "api", "worker", "beat", "storefront", "dashboard",
-    "stripe-app", "inventory-ops-app", "buylist-app", "pos-app", "mtg-import-app",
+    "stripe-app", "inventory-ops-app", "pos-app",
     "meilisearch", "migrate"
   ])
 
@@ -814,7 +814,7 @@ resource "aws_ecs_service" "apps" {
 locals {
   enable_scaling = var.enable_autoscaling || var.enable_scheduled_scaling
 
-  # All apps participate in auto-scaling (including batch jobs like mtg-import).
+  # All apps participate in auto-scaling.
   # Batch jobs (desired_count=0) get scale-up min=0 so they don't auto-start,
   # but their max is restored so they CAN be started manually during business hours.
   scalable_apps = local.enable_scaling && var.apps_enabled ? var.apps : {}

--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "github_actions_assume" {
 
     # Restrict to specific repo and branch (hardened per GPT-5.2 and Gemini 3 reviews)
     # SECURITY: Using StringEquals (not StringLike) to prevent wildcard bypass
-    # Only exact branch match and environment-based claims are allowed
+    # Only exact branch match, environment-based claims, and PR events are allowed
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
@@ -68,7 +68,9 @@ data "aws_iam_policy_document" "github_actions_assume" {
         "repo:${var.github_org}/${var.github_repo}:ref:refs/heads/${var.github_branch}",
         # Environment-based claim for workflows using GitHub Environments
         # This enforces GitHub Environment protection rules (required reviewers)
-        "repo:${var.github_org}/${var.github_repo}:environment:${var.environment}"
+        "repo:${var.github_org}/${var.github_repo}:environment:${var.environment}",
+        # Pull request events — needed for terraform plan on PRs (read-only)
+        "repo:${var.github_org}/${var.github_repo}:pull_request"
       ]
     }
   }

--- a/infra/terraform/modules/secrets/main.tf
+++ b/infra/terraform/modules/secrets/main.tf
@@ -179,7 +179,7 @@ resource "aws_ssm_parameter" "inventory_database_url" {
   name        = "${local.ssm_path_prefix}/apps/inventory-ops/DATABASE_URL"
   type        = "SecureString"
   value       = "postgresql://${var.rds_username}:${var.rds_password}@${var.rds_endpoint}/inventory_ops"
-  description = "PostgreSQL connection URL for inventory apps (inventory-ops, buylist, pos, mtg-import)"
+  description = "PostgreSQL connection URL for inventory apps (inventory-ops, pos)"
 
   tags = {
     Name        = "${local.name_prefix}-inventory-database-url"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -449,20 +449,8 @@ variable "inventory_ops_app_image_tag" {
   default     = "staging-latest"
 }
 
-variable "buylist_app_image_tag" {
-  description = "Buylist app image tag"
-  type        = string
-  default     = "staging-latest"
-}
-
 variable "pos_app_image_tag" {
   description = "POS app image tag"
-  type        = string
-  default     = "staging-latest"
-}
-
-variable "mtg_import_app_image_tag" {
-  description = "MTG Import app image tag"
   type        = string
   default     = "staging-latest"
 }

--- a/scripts/bootstrap-environment.sh
+++ b/scripts/bootstrap-environment.sh
@@ -248,7 +248,7 @@ log_info "========================================="
 log_info "Step 5/5: Force-restart ECS services"
 log_info "========================================="
 
-SERVICES=(api worker beat storefront dashboard stripe inventory-ops buylist pos meilisearch)
+SERVICES=(api worker beat storefront dashboard stripe inventory-ops pos meilisearch)
 
 for svc in "${SERVICES[@]}"; do
     log_info "Restarting: ${svc}..."
@@ -295,15 +295,13 @@ log_info ""
 log_info "3. Install Saleor apps (via Dashboard → Apps → Install external app):"
 log_info "   - Stripe:        https://apps.staging.michaelbean.org/apps/stripe/api/manifest"
 log_info "   - Inventory Ops: https://apps.staging.michaelbean.org/apps/inventory/api/manifest"
-log_info "   - Buylist:       https://apps.staging.michaelbean.org/apps/buylist/api/manifest"
 log_info "   - POS:           https://apps.staging.michaelbean.org/apps/pos/api/manifest"
-log_info "   - MTG Import:    https://apps.staging.michaelbean.org/apps/mtg-import/api/manifest"
 log_info ""
 log_info "4. Configure Stripe webhooks (in Stripe Dashboard):"
 log_info "   Endpoint: https://apps.staging.michaelbean.org/apps/stripe/api/webhooks/stripe"
 log_info ""
 log_info "5. Import MTG catalog (30-60 min):"
-log_info "   Trigger mtg-import ECS task or use Dashboard"
+log_info "   Use Inventory Ops app Import section in Dashboard"
 log_info ""
 log_info "6. Trigger initial price sync:"
 log_info "   After import completes, run the price sync cron endpoint"

--- a/scripts/deploy/aws/deploy-service.sh
+++ b/scripts/deploy/aws/deploy-service.sh
@@ -51,9 +51,7 @@ declare -A IMAGE_MAP=(
     ["storefront"]="${ECR_REGISTRY}/saleor-platform/storefront:${SHA}"
     ["stripe"]="${ECR_REGISTRY}/saleor-platform/stripe-app:${SHA}"
     ["inventory-ops"]="${ECR_REGISTRY}/saleor-platform/inventory-ops-app:${SHA}"
-    ["buylist"]="${ECR_REGISTRY}/saleor-platform/buylist-app:${SHA}"
     ["pos"]="${ECR_REGISTRY}/saleor-platform/pos-app:${SHA}"
-    ["mtg-import"]="${ECR_REGISTRY}/saleor-platform/mtg-import-app:${SHA}"
     ["meilisearch"]="KEEP"
 )
 
@@ -125,9 +123,7 @@ else
         case "$SERVICE" in
             stripe) REPO_NAME="saleor-platform/stripe-app" ;;
             inventory-ops) REPO_NAME="saleor-platform/inventory-ops-app" ;;
-            buylist) REPO_NAME="saleor-platform/buylist-app" ;;
             pos) REPO_NAME="saleor-platform/pos-app" ;;
-            mtg-import) REPO_NAME="saleor-platform/mtg-import-app" ;;
             *) REPO_NAME="saleor-platform/${SERVICE}" ;;
         esac
         if ! image_exists_in_ecr "$REPO_NAME" "$SHA"; then

--- a/scripts/deploy/aws/deploy-single.sh
+++ b/scripts/deploy/aws/deploy-single.sh
@@ -6,7 +6,7 @@
 # Usage: ./deploy-single.sh <environment> <service> [--skip-wait] [--dry-run]
 #
 # Services:
-#   storefront, stripe, inventory-ops, buylist, pos, mtg-import
+#   storefront, stripe, inventory-ops, pos
 #
 # Examples:
 #   ./deploy-single.sh staging inventory-ops          # Build + deploy inventory-ops
@@ -50,7 +50,7 @@ done
 if [[ -z "$ENV" || -z "$SERVICE" ]]; then
     echo "Usage: $0 <environment> <service> [--skip-wait] [--dry-run]"
     echo ""
-    echo "Services: storefront, stripe, inventory-ops, buylist, pos, mtg-import"
+    echo "Services: storefront, stripe, inventory-ops, pos"
     exit 1
 fi
 
@@ -81,44 +81,34 @@ declare -A ECR_REPO_MAP=(
     ["storefront"]="saleor-platform/storefront"
     ["stripe"]="saleor-platform/stripe-app"
     ["inventory-ops"]="saleor-platform/inventory-ops-app"
-    ["buylist"]="saleor-platform/buylist-app"
     ["pos"]="saleor-platform/pos-app"
-    ["mtg-import"]="saleor-platform/mtg-import-app"
 )
 
 declare -A CONTEXT_MAP=(
     ["storefront"]="./storefront"
     ["stripe"]="./saleor-apps"
     ["inventory-ops"]="./saleor-apps"
-    ["buylist"]="./saleor-apps"
     ["pos"]="./saleor-apps"
-    ["mtg-import"]="./saleor-apps"
 )
 
 declare -A DOCKERFILE_MAP=(
     ["storefront"]="./storefront/Dockerfile"
     ["stripe"]="./saleor-apps/apps/stripe/Dockerfile"
     ["inventory-ops"]="./saleor-apps/apps/inventory-ops/Dockerfile"
-    ["buylist"]="./saleor-apps/apps/buylist/Dockerfile"
     ["pos"]="./saleor-apps/apps/pos/Dockerfile"
-    ["mtg-import"]="./saleor-apps/apps/mtg-import/Dockerfile"
 )
 
 declare -A ECS_SERVICE_MAP=(
     ["storefront"]="storefront"
     ["stripe"]="stripe"
     ["inventory-ops"]="inventory-ops"
-    ["buylist"]="buylist"
     ["pos"]="pos"
-    ["mtg-import"]="mtg-import"
 )
 
 declare -A BASE_PATH_MAP=(
     ["stripe"]="/apps/stripe"
     ["inventory-ops"]="/apps/inventory"
-    ["buylist"]="/apps/buylist"
     ["pos"]="/apps/pos"
-    ["mtg-import"]="/apps/mtg-import"
 )
 
 # Validate service name

--- a/scripts/deploy/aws/rollback.sh
+++ b/scripts/deploy/aws/rollback.sh
@@ -53,7 +53,7 @@ CLUSTER="$(get_cluster_name "$ENV")"
 
 # Services to rollback
 if [[ "$SERVICE" == "all" ]]; then
-    SERVICES=(api worker storefront dashboard stripe-app inventory-ops-app buylist-app pos-app)
+    SERVICES=(api worker storefront dashboard stripe-app inventory-ops-app pos-app)
 else
     SERVICES=("$SERVICE")
 fi

--- a/scripts/deploy/aws/run-migrations.sh
+++ b/scripts/deploy/aws/run-migrations.sh
@@ -7,7 +7,7 @@
 # Arguments:
 #   environment - staging or production
 #   type        - django or prisma
-#   app         - (prisma only) app name: inventory-ops, mtg-import (default: inventory-ops)
+#   app         - (prisma only) app name: inventory-ops (default: inventory-ops)
 #
 # Required Environment Variables:
 #   ECS_TASK_SUBNETS          - Comma-separated subnet IDs for task networking
@@ -38,7 +38,7 @@ PRISMA_APP="${3:-inventory-ops}"  # Default to inventory-ops for backwards compa
 if [[ -z "$ENV" || -z "$MIGRATION_TYPE" ]]; then
     log_error "Usage: $0 <environment> <type> [app]"
     log_error "  type: django or prisma"
-    log_error "  app:  (prisma only) inventory-ops, mtg-import (default: inventory-ops)"
+    log_error "  app:  (prisma only) inventory-ops (default: inventory-ops)"
     exit 1
 fi
 
@@ -50,11 +50,11 @@ fi
 # Validate Prisma app name
 if [[ "$MIGRATION_TYPE" == "prisma" ]]; then
     case "$PRISMA_APP" in
-        inventory-ops|mtg-import)
+        inventory-ops)
             ;;
         *)
             log_error "Invalid Prisma app: ${PRISMA_APP}"
-            log_error "Valid apps: inventory-ops, mtg-import"
+            log_error "Valid apps: inventory-ops"
             exit 1
             ;;
     esac
@@ -329,7 +329,6 @@ else
     # Map Prisma app names to ECR image names
     declare -A PRISMA_IMAGE_MAP=(
         ["inventory-ops"]="inventory-ops-app"
-        ["mtg-import"]="mtg-import-app"
     )
 
     # Override container image with newly-built image if SHA is provided

--- a/scripts/smoke/apps-smoke.sh
+++ b/scripts/smoke/apps-smoke.sh
@@ -33,13 +33,11 @@ FAILURES=0
 APPS=(
   "stripe|/apps/stripe|3001"
   "inventory-ops|/apps/inventory|3002"
-  "buylist|/apps/buylist|3003"
   "pos|/apps/pos|3004"
-  "mtg-import|/apps/mtg-import|3005"
 )
 
 # Apps that run on-demand (desired_count=0) — accept 503 as passing
-ON_DEMAND_APPS=("mtg-import")
+ON_DEMAND_APPS=()
 
 log_info() {
   echo -e "${GREEN}[INFO]${NC} $1"


### PR DESCRIPTION
## Summary
- **Phases 1-8**: Merged buylist and mtg-import app code into the unified inventory-ops app (routers, UI, Prisma models, webhooks)
- **Phase 9**: Removed buylist + mtg-import from Terraform infrastructure (ECS services, ALB rules, CloudWatch logs)
- **Phase 10**: Added Prisma migration for `ImportedProduct.installationId` (tenant-scoped unique constraint with safe backfill from ImportJob)
- **Phase 11**: Removed all remaining buylist/mtg-import references from CI/CD, deploy scripts, docker-compose, smoke tests. Added OIDC PR subject to terraform plan IAM role.

### Infrastructure changes
- Terraform: 21 added, 4 changed, 17 destroyed (buylist/mtg-import ECS services, ALB target groups/rules, CloudWatch log groups removed)
- inventory-ops memory bumped 512 to 1024 MB to handle consolidated workload
- ECR repos intentionally kept for rollback capability
- IAM trust policy now allows PR-triggered terraform plan via OIDC

### Post-merge steps
1. `terraform apply` to update IAM trust policy + remove ECS services
2. CI deploys consolidated inventory-ops + runs Prisma migration
3. Dashboard: uninstall old buylist (QXBwOjMy) + mtg-import (QXBwOjMw) apps
4. Dashboard: re-install inventory-ops with expanded permissions + webhooks
5. Verify: buylist flow, import jobs, price sync, store credit, all webhooks

## Test plan
- [x] CI build passes for inventory-ops (Apps Checks: PASS)
- [ ] Prisma migration applies cleanly
- [ ] Terraform plan shows expected changes only (verified locally)
- [ ] Terraform apply succeeds
- [ ] Buylist creation + FOH/BOH workflow functional
- [ ] MTG import job runs successfully
- [ ] Price sync cron operates normally

Generated with [Claude Code](https://claude.com/claude-code)