### PR TITLE
fix: CI Gate + auto-merge PAT for deploy trigger

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -2,22 +2,46 @@
 
 > **Full procedures**: See `docs/reference/git-philosophy.md` for complete workflow.
 
-## Branch Protection (CRITICAL)
+## Branch Model (CRITICAL)
 
-| Branch | Status |
-|--------|--------|
-| `main` | **NEVER MODIFY** — mirrors upstream |
-| `platform/main` | Primary work branch |
-| `feature/*` | Development branches |
+| Branch | Purpose |
+|--------|---------|
+| `main` | **NEVER MODIFY** — mirrors upstream `saleor/saleor-platform`. Used only to pull Saleor updates. |
+| `platform/main` | **Default branch.** All our work targets here. GitHub default branch is set to this. |
+| `feature/*` | Short-lived development branches. Created off `platform/main`, merged back via PR. |
+
+`platform/main` is the GitHub default branch. This is intentional — `workflow_run` triggers, PR defaults, and `git clone` all use `platform/main`. `main` exists solely as an upstream tracking branch.
 
 Always verify before changes:
 ```bash
 git branch --show-current  # Must NOT show "main"
 ```
 
+## PR-First Workflow (CRITICAL)
+
+**All changes must go through pull requests. Never push directly to `platform/main`.**
+
+```
+feature/* branch → push → PR targeting platform/main → test-platform CI → auto-merge → deploy-staging
+```
+
+1. Create a `feature/*` branch off `platform/main`
+2. Make changes, commit, push the feature branch
+3. Create a PR targeting `platform/main` with the `auto-merge` label
+4. `test-platform` CI runs automatically (lint, tests, builds, security)
+5. `auto-merge.yml` fires on `test-platform` completion — squash-merges if all required checks pass
+6. `deploy-staging.yml` triggers on merge to `platform/main` — deploys to AWS
+
+For submodule changes (saleor-apps/inventory-ops/etc.):
+- Push changes to the submodule's branch first
+- Update the submodule pointer in the platform repo's feature branch
+- The PR and CI/CD pipeline always runs on the **platform** repo
+
 ## Prohibited Actions
 
+- Push directly to `platform/main` (use PRs)
 - Force-push to `platform/main`
+- Commit to or modify `main` (upstream mirror)
 - Commit secrets or `.env` files
 - Large reformatting of upstream files
 - Breaking dependency upgrades without isolation

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -130,7 +130,10 @@ jobs:
         if: steps.check.outputs.eligible == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # MUST use PAT, not GITHUB_TOKEN — merges via GITHUB_TOKEN don't
+          # trigger downstream workflows (push → deploy-staging). GitHub
+          # prevents this to avoid infinite loops.
+          github-token: ${{ secrets.SUBMODULES_TOKEN }}
           script: |
             const prNumber = parseInt('${{ steps.pr.outputs.number }}');
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -88,14 +88,9 @@ jobs:
               return;
             }
 
-            // Only check required status checks (non-required failures should not block merge)
+            // Only check the CI Gate job (aggregates all conditional checks)
             const requiredChecks = [
-              'Storefront Checks',
-              'Apps Checks',
-              'Container Builds',
-              'Docker Compose Validation',
-              'Migration Validation',
-              'Terraform Validation',
+              'CI Gate',
             ];
 
             const { data: checks } = await github.rest.checks.listForRef({

--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -528,3 +528,35 @@ jobs:
         with:
           name: localreview-report
           path: docs/ai-reviews/localreview.md
+
+  # =============================================================================
+  # CI GATE — single required status check for branch protection
+  # =============================================================================
+  # All conditional jobs feed into this gate. Branch protection only requires
+  # this job, so skipped conditional jobs don't block merging.
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - verify_storefront
+      - verify_apps
+      - validate_migrations
+      - security_scan
+      - verify_builds
+      - validate_compose
+      - terraform_validate
+      - localreview_ci
+    steps:
+      - name: Check results
+        run: |
+          # Fail if any required job failed (skipped is OK)
+          results="${{ needs.verify_storefront.result }} ${{ needs.verify_apps.result }} ${{ needs.validate_migrations.result }} ${{ needs.security_scan.result }} ${{ needs.verify_builds.result }} ${{ needs.validate_compose.result }} ${{ needs.terraform_validate.result }} ${{ needs.localreview_ci.result }}"
+          echo "Job results: $results"
+          for result in $results; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "::error::One or more CI jobs failed or were cancelled"
+              exit 1
+            fi
+          done
+          echo "All CI checks passed or were skipped (no relevant changes)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,9 @@ Key extensions live in `saleor-apps/apps/` and integrate tightly with pricing, i
 
 | Rule | Details |
 |------|---------|
-| **Never commit to `main`** | `main` mirrors upstream `saleor/saleor-platform` |
-| **Work on `platform/main` or `feature/*`** | These are the only branches for changes |
+| **Never commit to `main`** | `main` mirrors upstream `saleor/saleor-platform` — exists only for pulling Saleor updates |
+| **PR-first workflow** | All changes go through PRs targeting `platform/main`. Never push directly. See `.claude/rules/git-workflow.md` |
+| **Work on `feature/*` branches** | Create off `platform/main`, merge back via PR with `auto-merge` label |
 | **Prefer extension over modification** | Use Saleor Apps, webhooks, workers, env configuration |
 | **Always verify the active branch** | `git branch --show-current` before any changes |
 | **No untracked infrastructure changes** | Manual AWS changes must be logged and reconciled with Terraform |


### PR DESCRIPTION
## Summary
- Add CI Gate aggregator job to test-platform (skipped conditional jobs no longer block merge)
- Use PAT instead of GITHUB_TOKEN for auto-merge (fixes deploy-staging not triggering)
- Document PR-first workflow in CLAUDE.md and git-workflow.md

## Root causes fixed
1. Branch protection required conditional jobs that get skipped when no relevant files change
2. GITHUB_TOKEN merges don't create push events that trigger downstream workflows

## Test plan
- [ ] test-platform CI passes with CI Gate job
- [ ] Auto-merge triggers after CI Gate passes
- [ ] deploy-staging triggers after merge to platform/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)