### PR TITLE
fix: handle nested errors in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -147,18 +147,27 @@ jobs:
               console.log(`PR #${prNumber} merged via squash`);
 
               // Add merged comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: '🤖 Auto-merged after all CI checks passed.',
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: '🤖 Auto-merged after all CI checks passed.',
+                });
+              } catch (commentErr) {
+                console.log(`Merge succeeded but comment failed: ${commentErr.message}`);
+              }
             } catch (e) {
               console.log(`Merge failed: ${e.message}`);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: `⚠️ Auto-merge failed: ${e.message}`,
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: `⚠️ Auto-merge failed: ${e.message}`,
+                });
+              } catch (commentErr) {
+                console.log(`Comment also failed: ${commentErr.message}`);
+              }
+              core.setFailed(`Auto-merge failed for PR #${prNumber}: ${e.message}`);
             }


### PR DESCRIPTION
## Summary
- Wraps comment API calls in try/catch so a PAT permission error on comments doesn't mask the merge result
- Adds `core.setFailed()` on merge failure for clearer CI status
- Prevents the cascading unhandled error seen in run #22983059692 (PR #72)

## Test plan
- [ ] Verify auto-merge workflow succeeds on next PR with updated PAT permissions
- [ ] Confirm merge failure properly reports via `core.setFailed()` instead of unhandled throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)