### PR TITLE
fix: replace inline server actions with stable exports

### DIFF
--- a/storefront/src/app/singles-builder/[channel]/actions.ts
+++ b/storefront/src/app/singles-builder/[channel]/actions.ts
@@ -499,6 +499,37 @@ export async function updateCartMetadata(
 	}
 }
 
+// ----- Stable Server Actions for Client Components -----
+// These are top-level exports with stable IDs that survive deployments.
+// Do NOT use inline "use server" closures in server components — they get
+// unique IDs per build and break after redeployment.
+
+export interface FetchMoreFilters {
+	conditions?: string[];
+	finishes?: string[];
+	rarity?: string[];
+	inStockOnly?: boolean;
+	priceMin?: number | null;
+	priceMax?: number | null;
+}
+
+export async function fetchMoreProducts(
+	channel: string,
+	search: string,
+	after: string | null,
+	filters: FetchMoreFilters,
+): Promise<SinglesBuilderSearchQuery["products"]> {
+	return fetchMoreWithMeilisearch(search, channel, after, filters);
+}
+
+export async function addToCart(
+	variantId: string,
+	quantity: number,
+	channel: string,
+): Promise<CartActionResult> {
+	return addToSinglesCart(variantId, quantity, channel);
+}
+
 // POS handoff: Set customer name, notes, short code, and staff email for auto-import
 export async function saveCartForPOS(
 	customerName: string,

--- a/storefront/src/app/singles-builder/[channel]/components/SinglesResultsWrapper.tsx
+++ b/storefront/src/app/singles-builder/[channel]/components/SinglesResultsWrapper.tsx
@@ -6,8 +6,8 @@ import type { SinglesBuilderProductFragment, SinglesBuilderSearchQuery } from "@
 import { SinglesResults } from "./SinglesResults";
 import type { CartLineInfo } from "./SinglesResultItem";
 import { useSinglesCartStore, type CartLine } from "../store";
-import type { CartActionResult } from "../actions";
-import { updateCartLineQuantity, removeCartLine } from "../actions";
+import type { CartActionResult, FetchMoreFilters } from "../actions";
+import { fetchMoreProducts, addToCart, updateCartLineQuantity, removeCartLine } from "../actions";
 import type { SinglesFilterState } from "./filterTypes";
 import { matchesVariantFilters } from "./buildSinglesFilter";
 
@@ -31,12 +31,6 @@ interface SinglesResultsWrapperProps {
 	channel: string;
 	searchQuery: string;
 	filterState?: SinglesFilterState;
-	fetchMoreAction: (
-		channel: string,
-		search: string,
-		after: string | null,
-	) => Promise<SinglesBuilderSearchQuery["products"]>;
-	addToCartAction: (variantId: string, quantity: number) => Promise<CartActionResult>;
 }
 
 export function SinglesResultsWrapper({
@@ -44,8 +38,6 @@ export function SinglesResultsWrapper({
 	channel,
 	searchQuery,
 	filterState,
-	fetchMoreAction,
-	addToCartAction,
 }: SinglesResultsWrapperProps) {
 	const [products, setProducts] = useState<SinglesBuilderProductFragment[]>(
 		initialData?.edges.map((e) => e.node) || [],
@@ -101,12 +93,22 @@ export function SinglesResultsWrapper({
 		return result;
 	}, [products, searchQuery, filterState, hasVariantFilters]);
 
+	// Build filter params from filterState for the stable server action
+	const fetchMoreFilters: FetchMoreFilters = useMemo(() => ({
+		conditions: filterState?.condition,
+		finishes: filterState?.finish,
+		rarity: filterState?.rarity,
+		inStockOnly: filterState?.inStockOnly,
+		priceMin: filterState?.priceMin,
+		priceMax: filterState?.priceMax,
+	}), [filterState]);
+
 	const handleLoadMore = useCallback(() => {
 		if (!pageInfo?.hasNextPage || !pageInfo?.endCursor || isPending) return;
 
 		startTransition(async () => {
 			try {
-				const moreData = await fetchMoreAction(channel, searchQuery, pageInfo.endCursor ?? null);
+				const moreData = await fetchMoreProducts(channel, searchQuery, pageInfo.endCursor ?? null, fetchMoreFilters);
 				if (moreData) {
 					setProducts((prev) => [...prev, ...moreData.edges.map((e) => e.node)]);
 					setPageInfo(moreData.pageInfo);
@@ -116,7 +118,7 @@ export function SinglesResultsWrapper({
 				toast.error("Failed to load more results");
 			}
 		});
-	}, [channel, searchQuery, pageInfo, isPending, fetchMoreAction]);
+	}, [channel, searchQuery, pageInfo, isPending, fetchMoreFilters]);
 
 	const { cart, setCart } = useSinglesCartStore();
 
@@ -157,14 +159,14 @@ export function SinglesResultsWrapper({
 	const handleQuickAdd = useCallback(
 		async (variantId: string, quantity: number) => {
 			try {
-				const result = await addToCartAction(variantId, quantity);
+				const result = await addToCart(variantId, quantity, channel);
 				handleCartResult(result, "Added to cart!");
 			} catch (error) {
 				console.error("Failed to add to cart:", error);
 				toast.error("Failed to add to cart");
 			}
 		},
-		[addToCartAction, handleCartResult],
+		[channel, handleCartResult],
 	);
 
 	const handleUpdateQuantity = useCallback(

--- a/storefront/src/app/singles-builder/[channel]/page.tsx
+++ b/storefront/src/app/singles-builder/[channel]/page.tsx
@@ -12,10 +12,8 @@ import {
 } from "./components";
 import { buildSinglesFilter } from "./components/buildSinglesFilter";
 import {
-	addToSinglesCart,
 	searchWithMeilisearch,
 	transformMeilisearchToGraphQL,
-	fetchMoreWithMeilisearch,
 } from "./actions";
 
 interface PageProps {
@@ -75,36 +73,12 @@ async function SearchResults({
 	// Transform to GraphQL-compatible format
 	const products = await transformMeilisearchToGraphQL(meilisearchResult);
 
-	// Bind the channel and filters to the action for "load more" using Meilisearch
-	const boundFetchMore = async (
-		channel: string,
-		search: string,
-		after: string | null,
-	) => {
-		"use server";
-		return fetchMoreWithMeilisearch(search, channel, after, {
-			conditions: filterState.condition,
-			finishes: filterState.finish,
-			rarity: filterState.rarity,
-			inStockOnly: filterState.inStockOnly,
-			priceMin: filterState.priceMin,
-			priceMax: filterState.priceMax,
-		});
-	};
-
-	const boundAddToCart = async (variantId: string, quantity: number) => {
-		"use server";
-		return addToSinglesCart(variantId, quantity, channel);
-	};
-
 	return (
 		<SinglesResultsWrapper
 			initialData={products}
 			channel={channel}
 			searchQuery={searchQuery}
 			filterState={filterState}
-			fetchMoreAction={boundFetchMore}
-			addToCartAction={boundAddToCart}
 		/>
 	);
 }


### PR DESCRIPTION
## Summary

- Inline `"use server"` closures in the singles builder page (`boundFetchMore`, `boundAddToCart`) got unique IDs per build. After deployment, clients with cached pages referenced stale action IDs — **every load-more and add-to-cart call failed** with `Failed to find Server Action`
- Moved to stable top-level exports (`fetchMoreProducts`, `addToCart`) in `actions.ts` that persist across deployments
- Client component now calls these directly with filter state as explicit parameters

## Root Cause

CloudWatch logs showed repeated:
```
Error: Failed to find Server Action. This request might be from an older or newer deployment.
```

## Test plan

- [ ] Deploy to staging and verify "load more" pagination works in singles builder
- [ ] Verify add-to-cart works after a fresh page load
- [ ] Verify filters are correctly passed through to load-more calls
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)