### PR TITLE
fix: remove request queue throttling + deduplicate SetIcon requests

### DIFF
--- a/storefront/src/lib/filters/getTrendingProducts.ts
+++ b/storefront/src/lib/filters/getTrendingProducts.ts
@@ -14,7 +14,7 @@ import type { ProductListItemFragment } from "@/gql/graphql";
  * Create these collections in Saleor Dashboard to enable manual curation.
  * The first collection found with products will be used.
  */
-const TRENDING_COLLECTION_SLUGS = ["featured", "trending", "bestsellers", "popular"];
+const TRENDING_COLLECTION_SLUGS = ["trending"];
 
 // Simple logging helper for server-side debugging
 function logError(context: string, error: unknown) {

--- a/storefront/src/lib/graphql.ts
+++ b/storefront/src/lib/graphql.ts
@@ -2,7 +2,6 @@ import { invariant } from "ts-invariant";
 import { type TypedDocumentString } from "../gql/graphql";
 import { getServerAuthClient } from "@/app/config";
 import { withRetry } from "./fetch-retry";
-import { requestQueue } from "./request-queue";
 
 type GraphQLErrorResponse = {
 	errors: readonly {
@@ -42,14 +41,14 @@ export async function executeGraphQL<Result, Variables>(
 		next: { revalidate },
 	};
 
-	const response = await requestQueue.enqueue(async () => {
+	const response = await (async () => {
 		if (withAuth) {
 			const authClient = await getServerAuthClient();
 			const authFetch = withRetry(authClient.fetchWithAuth.bind(authClient));
 			return authFetch(apiUrl, input);
 		}
 		return resilientFetch(apiUrl, input);
-	});
+	})();
 
 	if (!response.ok) {
 		const body = await (async () => {

--- a/storefront/src/ui/components/SetIcon.tsx
+++ b/storefront/src/ui/components/SetIcon.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 
 // Rarity colors for set icons (traditional MTG rarity colors)
 const RARITY_ICON_COLORS: Record<string, string> = {
@@ -22,40 +22,70 @@ const SIZES = {
 	lg: "h-6 w-6",
 };
 
-export function SetIcon({ setCode, rarity, size = "md" }: SetIconProps) {
-	const [hasError, setHasError] = useState(false);
-	const color = RARITY_ICON_COLORS[rarity?.toLowerCase() || ""] || "#1a1a1a";
-	// Use local proxy to avoid CORS issues with CSS mask-image
-	const iconUrl = `/api/scryfall-icon?set=${setCode.toLowerCase()}`;
+// Module-level cache shared across all SetIcon instances.
+// Prevents repeated network requests for set codes that already 404'd.
+type IconState = "loading" | "ok" | "error";
+const iconStatus = new Map<string, IconState>();
+const listeners = new Set<() => void>();
 
-	// Use CSS mask for the icon with color support
-	if (!hasError) {
+function getIconSnapshot() {
+	return iconStatus;
+}
+
+function getIconServerSnapshot() {
+	return iconStatus;
+}
+
+function subscribeToIcons(callback: () => void) {
+	listeners.add(callback);
+	return () => listeners.delete(callback);
+}
+
+function setIconStatus(key: string, status: IconState) {
+	iconStatus.set(key, status);
+	for (const listener of listeners) {
+		listener();
+	}
+}
+
+function probeIcon(key: string, iconUrl: string) {
+	if (iconStatus.has(key)) return;
+	iconStatus.set(key, "loading");
+	const img = new Image();
+	img.src = iconUrl;
+	img.onload = () => setIconStatus(key, "ok");
+	img.onerror = () => setIconStatus(key, "error");
+}
+
+export function SetIcon({ setCode, rarity, size = "md" }: SetIconProps) {
+	const key = setCode.toLowerCase();
+	const color = RARITY_ICON_COLORS[rarity?.toLowerCase() || ""] || "#1a1a1a";
+	const iconUrl = `/api/scryfall-icon?set=${key}`;
+
+	const store = useSyncExternalStore(subscribeToIcons, getIconSnapshot, getIconServerSnapshot);
+	const status = store.get(key) ?? "loading";
+
+	useEffect(() => {
+		probeIcon(key, iconUrl);
+	}, [key, iconUrl]);
+
+	if (status === "loading" || status === "ok") {
 		return (
-			<>
-				{/* Hidden img to detect load errors */}
-				{/* eslint-disable-next-line @next/next/no-img-element */}
-				<img
-					src={iconUrl}
-					alt=""
-					className="hidden"
-					onError={() => setHasError(true)}
-				/>
-				<span
-					className={`inline-block flex-shrink-0 ${SIZES[size]}`}
-					style={{
-						WebkitMaskImage: `url(${iconUrl})`,
-						maskImage: `url(${iconUrl})`,
-						WebkitMaskSize: "contain",
-						maskSize: "contain",
-						WebkitMaskRepeat: "no-repeat",
-						maskRepeat: "no-repeat",
-						WebkitMaskPosition: "center",
-						maskPosition: "center",
-						backgroundColor: color,
-					}}
-					title={`Set: ${setCode.toUpperCase()}`}
-				/>
-			</>
+			<span
+				className={`inline-block flex-shrink-0 ${SIZES[size]}`}
+				style={{
+					WebkitMaskImage: status === "ok" ? `url(${iconUrl})` : undefined,
+					maskImage: status === "ok" ? `url(${iconUrl})` : undefined,
+					WebkitMaskSize: "contain",
+					maskSize: "contain",
+					WebkitMaskRepeat: "no-repeat",
+					maskRepeat: "no-repeat",
+					WebkitMaskPosition: "center",
+					maskPosition: "center",
+					backgroundColor: status === "ok" ? color : "transparent",
+				}}
+				title={`Set: ${setCode.toUpperCase()}`}
+			/>
 		);
 	}
 


### PR DESCRIPTION
## Summary

- **Remove GraphQL request queue** — the queue (3 concurrent, 200ms delay) was throttling all SSR GraphQL calls, causing 16 RSC prefetches to pile up and making links unresponsive for seconds after page load
- **Deduplicate SetIcon fetches** — module-level cache via `useSyncExternalStore` prevents repeated 404 requests for the same set code across all instances (was firing 2 requests per icon per instance)
- **Trim trending collection slugs** — was sequentially trying 4 non-existent collections before falling back, adding ~1.4s to homepage SSR

Retry logic (`withRetry`) is preserved. See #77 for follow-up on proper queue values.

## Test plan

- [ ] Staging storefront loads in < 2s (was 4-9s)
- [ ] Navigation links respond immediately on click (no hydration delay)
- [ ] SetIcon shows fallback badge for promo sets, colored icon for valid sets
- [ ] Console 404 errors reduced (deduplicated per set code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)