### PR TITLE
feat: add Grafana Faro collector URL for storefront RUM

### DIFF
--- a/infra/terraform/environments/staging.tfvars
+++ b/infra/terraform/environments/staging.tfvars
@@ -176,7 +176,7 @@ grafana_url = "https://michaelbean.grafana.net/"
 # Grafana Faro RUM (Frontend Observability)
 # To get the URL: Grafana Cloud → Frontend → Applications → New Application → "storefront"
 # Format: https://faro-collector-prod-us-west-0.grafana.net/collect/<app-key>
-# grafana_faro_url = ""
+grafana_faro_url = "https://faro-collector-prod-us-west-0.grafana.net/collect/5fdc8fffb376243bea13f2ad1287e2bc"
 
 # Grafana Cloud OTEL data sources (pre-existing, managed by Grafana Cloud)
 tempo_datasource_uid      = "grafanacloud-traces"


### PR DESCRIPTION
## Summary
- Uncomment and set `grafana_faro_url` in staging.tfvars
- Enables Grafana Frontend Observability (Faro) for client-side RUM
- Faro app "storefront" created in Grafana Cloud (app key: `5fdc8fffb376243bea13f2ad1287e2bc`)
- CORS origins: staging.michaelbean.org, www.staging.michaelbean.org

## Test plan
- [x] `terraform apply` succeeded — storefront task def updated with `NEXT_PUBLIC_GRAFANA_FARO_URL`
- [x] Storefront deployed and serving pages with FaroObservability component
- [ ] Verify Faro RUM data appears in Grafana Cloud → Frontend Observability after browser visits

🤖 Generated with [Claude Code](https://claude.com/claude-code)