### PR TITLE
perf: lazy-load below-fold content + paginate category pages

### DIFF
--- a/MEMORY/WORK/20260312-192500_storefront-speed-fix-plan/PRD.md
+++ b/MEMORY/WORK/20260312-192500_storefront-speed-fix-plan/PRD.md
@@ -1,0 +1,147 @@
+---
+task: Data-driven plan to fix storefront speed permanently
+slug: 20260312-192500_storefront-speed-fix-plan
+effort: advanced
+phase: build
+progress: 3/28
+mode: interactive
+started: 2026-03-12T19:25:00-07:00
+updated: 2026-03-12T20:45:00-07:00
+---
+
+## Context
+
+Michael has been "playing cat and mouse with website speed for weeks" and wants a definitive, data-driven fix. OTEL traces reveal two root causes:
+
+**Root Cause 1: GraphQL DataLoader waterfall on product list queries**
+- `ProductListFiltered` takes 1.3-2.4s due to N+1 DataLoader batches (AttributeValues, TaxClass, AvailableQuantity)
+- DB query itself is 50-65ms; overhead is all resolver-side
+- Affects: `/webstore/products`, paginated pages, category pages
+
+**Root Cause 2: Blocking SSR queries for below-fold content**
+- `RelatedProducts` (12 products × all variants) adds ~2s to every product detail page via SSR Promise.all
+- `OtherPrintings` fetches up to 50 products with full variant data, also blocks SSR
+- Both are below the fold on product detail pages
+
+**Root Cause 3: Over-sized page queries with no pagination**
+- `ProductListByCategory` fetches 100 products per page with NO pagination UI
+- `ProductListByCollection` fetches 100 products per set detail page with NO pagination UI
+- Each product triggers the full DataLoader waterfall (attributes, tax class, availability)
+
+**Constraints**:
+- ProductListItem fragment CANNOT be trimmed: stock badge needs `variants { quantityAvailable }`, set icon row needs `attributes`
+- `executeGraphQL` is server-only (uses Next.js `revalidate` + `getServerAuthClient`). Client-side lazy loading requires API route handlers.
+- `ProductListByCategory.graphql` and `ProductListByCollection.graphql` have NO cursor variables, NO pageInfo — must be modified before pagination can work.
+- Meilisearch has NO `category` field — cannot replace Saleor GraphQL for category pages or set detail tabs (singles/sealed split depends on `category.name`).
+- Set detail page (`/magic/sets/[slug]`) is currently unused — sets listing links to `/search?query=...&set=...` instead.
+
+**Scale**: 101k products in webstore, 76k in singles-builder. Most cards have 5-15 variants each.
+
+### Approach (v4 — final after two red team rounds)
+
+**Tier 1A — Lazy-load below-fold sections (biggest single win: ~2s off product detail SSR):**
+- Create API route handlers for RelatedProducts and OtherPrintings GraphQL queries
+- Move both queries out of product detail page SSR Promise.all
+- Load client-side via useEffect with skeleton placeholders
+- Both components already have `'use client'` directive — ready for client-side fetching
+
+**Tier 1B — Page size reduction + pagination (~75% less DataLoader work):**
+- Modify `ProductListByCategory.graphql` to accept cursor variables ($first, $after, $last, $before) and return pageInfo
+- Modify `ProductListByCollection.graphql` same way
+- Reduce `first: 100` → `first: 24` on category/collection/board-games queries
+- Add existing Pagination component to category, board-games pages
+- **DEFER set detail page pagination**: Tab interaction (client-side singles/sealed filtering) conflicts with server-side cursor pagination — requires deeper architectural work
+
+**Tier 2 — Cache tuning (5x fewer origin hits on stable pages):**
+- Increase `s-maxage` for sets/categories to 300s in middleware.ts
+- Add `stale-while-revalidate=300` to product detail pages
+
+**Tier 3 — Payload reduction:**
+- Paginate `/webstore/magic/sets` listing page (703KB response) — DEFERRED, lower priority
+
+### Red Team Findings (rounds 1 + 2)
+
+**Round 1:**
+- CRITICAL: Cannot remove `variants` from ProductListItem — stock badge depends on it
+- CRITICAL: Cannot remove `attributes` from ProductListItem — set icon row depends on it
+- CRITICAL: Categories/collections have NO pagination UI
+
+**Round 2:**
+- CRITICAL: `executeGraphQL` is server-only — lazy loading requires API route handlers (pattern exists: `/api/singles-builder/lookup`, `/api/contact`)
+- CRITICAL: `ProductListByCategory.graphql` has NO cursor variables, NO pageInfo — must modify query
+- CRITICAL: `ProductListByCollection.graphql` same — partial ($first only, no $after/$before, no pageInfo)
+- NO-GO: Meilisearch for set detail — no category field (can't split singles/sealed), no slug-to-set-code mapping, pagination model mismatch, page currently unused
+- MEDIUM: SEO risk from reducing 100→24 products — mitigated by adding rel="next/prev" link tags
+- MEDIUM: Set detail page tab filtering conflicts with cursor pagination — DEFERRED
+
+### Estimated Impact
+
+| Change | Est. savings | Pages affected |
+|--------|-------------|----------------|
+| Lazy-load RelatedProducts + OtherPrintings | ~2s off SSR | Every product detail page |
+| Reduce first:100→24 + pagination | ~75% less resolver time | Category + board-games pages |
+| Cache s-maxage 60→300s | 5x fewer origin hits | Sets listing, category pages |
+
+## Criteria
+
+### Tier 1A: Lazy Loading (Below-Fold Sections)
+- [ ] ISC-1: API route created for RelatedProducts query (/api/products/related)
+- [ ] ISC-2: API route created for OtherPrintings query (/api/products/other-printings)
+- [ ] ISC-3: RelatedProducts query removed from product page SSR Promise.all
+- [ ] ISC-4: RelatedProducts loads client-side via useEffect
+- [ ] ISC-5: Skeleton placeholder shown while RelatedProducts loads
+- [ ] ISC-6: OtherPrintings query removed from product page SSR Promise.all
+- [ ] ISC-7: OtherPrintings loads client-side via useEffect
+- [ ] ISC-8: Skeleton placeholder shown while OtherPrintings loads
+
+### Tier 1B: Page Size + Pagination
+- [ ] ISC-9: ProductListByCategory.graphql accepts $first, $after, $last, $before variables
+- [ ] ISC-10: ProductListByCategory.graphql returns pageInfo with cursors
+- [ ] ISC-11: ProductListByCollection.graphql accepts $after, $last, $before variables
+- [ ] ISC-12: ProductListByCollection.graphql returns pageInfo with cursors
+- [ ] ISC-13: Category page uses first:24 with Pagination component
+- [ ] ISC-14: Board games page uses first:24 with Pagination component
+- [ ] ISC-15: GraphQL codegen regenerated after query changes
+
+### Tier 2: Cache Tuning
+- [ ] ISC-16: Sets listing page s-maxage increased to 300s
+- [ ] ISC-17: Category pages s-maxage increased to 300s
+- [ ] ISC-18: Product detail pages have stale-while-revalidate=300
+
+### Performance Targets (origin-hit, bypass CDN)
+- [ ] ISC-19: Product detail page origin TTFB under 1.0s (from ~2.5s baseline)
+- [ ] ISC-20: Category page origin TTFB under 1.5s (from ~2.0s baseline)
+
+### Anti-criteria
+- [ ] ISC-A1: No regression in product detail variant selector
+- [ ] ISC-A2: No layout shift from lazy-loaded sections (skeleton matches final height)
+- [ ] ISC-A3: No broken images on product list pages
+- [ ] ISC-A4: Cart/checkout functionality unchanged
+- [ ] ISC-A5: SinglesBuilder search unaffected
+- [ ] ISC-A6: Set icon row still displays on all product cards
+
+### Verification
+- [ ] ISC-21: Before/after crawl benchmark documented
+- [x] ISC-22: Red team round 1 completed
+- [x] ISC-23: Red team round 2 completed — revised plan validated
+- [x] ISC-24: Plan reviewed before implementation begins
+- [ ] ISC-25: Codex review of changes passes
+- [ ] ISC-26: All changes on feature branch with PR
+- [ ] ISC-27: Storefront builds successfully after changes
+- [ ] ISC-28: TypeScript compilation passes with no new errors
+
+## Decisions
+
+- **D1**: Keep ProductListItem fragment unchanged — stock badge needs `variants`, set icon needs `attributes`
+- **D2**: Lazy-load BOTH RelatedProducts and OtherPrintings — both block SSR, both below fold
+- **D3**: Use API route handlers for client-side GraphQL — `executeGraphQL` is server-only
+- **D4**: Modify GraphQL query files to add cursor variables — current queries lack pagination support
+- **D5**: DEFER set detail page pagination — tab filtering (singles/sealed) conflicts with cursor pagination
+- **D6**: DEFER Meilisearch for set detail — NO-GO (no category field, no slug mapping, page unused)
+- **D7**: DEFER magic sets listing pagination — lower priority, 703KB is annoying but not blocking
+- **D8**: Add skeleton UI for lazy sections — prevents layout shift
+- **D9**: Measure origin TTFB not CDN — CDN-cached hits tell us nothing about the fix
+
+## Verification
+
+(populated during verification)

--- a/storefront/src/app/[channel]/(main)/board-games/[category]/page.tsx
+++ b/storefront/src/app/[channel]/(main)/board-games/[category]/page.tsx
@@ -2,9 +2,11 @@ import { type ResolvingMetadata, type Metadata } from "next";
 import Link from "next/link";
 import { ProductListByCategoryDocument } from "@/gql/graphql";
 import { executeGraphQL } from "@/lib/graphql";
+import { getPaginatedListVariables } from "@/lib/utils";
 import { Breadcrumb } from "@/ui/components/Breadcrumb";
 import { BoardGamesSubNav } from "@/ui/components/BoardGamesSubNav";
 import { ProductList } from "@/ui/components/ProductList";
+import { Pagination } from "@/ui/components/Pagination";
 import { Clock, ArrowLeft } from "lucide-react";
 
 export const dynamic = "force-dynamic";
@@ -39,10 +41,14 @@ export const generateMetadata = async (
 
 export default async function BoardGamesCategoryPage(props: {
 	params: Promise<{ category: string; channel: string }>;
+	searchParams: Promise<{ cursor?: string; direction?: string }>;
 }) {
-	const params = await props.params;
+	const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
+
+	const paginationVars = getPaginatedListVariables({ params: searchParams, pageSize: 24 });
+
 	const { category } = await executeGraphQL(ProductListByCategoryDocument, {
-		variables: { slug: params.category, channel: params.channel },
+		variables: { slug: params.category, channel: params.channel, ...paginationVars },
 		revalidate: 60,
 	});
 
@@ -135,7 +141,10 @@ export default async function BoardGamesCategoryPage(props: {
 					</div>
 
 					{products.edges.length > 0 ? (
-						<ProductList products={products.edges.map((e) => e.node)} />
+						<>
+							<ProductList products={products.edges.map((e) => e.node)} />
+							<Pagination pageInfo={products.pageInfo} />
+						</>
 					) : (
 						<div className="rounded-lg border border-neutral-200 bg-neutral-50 p-8 text-center">
 							<p className="text-neutral-500">No games found in this category.</p>

--- a/storefront/src/app/[channel]/(main)/categories/[slug]/page.tsx
+++ b/storefront/src/app/[channel]/(main)/categories/[slug]/page.tsx
@@ -4,7 +4,9 @@ import { ProductListByCategoryDocument } from "@/gql/graphql";
 
 export const dynamic = "force-dynamic";
 import { executeGraphQL } from "@/lib/graphql";
+import { getPaginatedListVariables } from "@/lib/utils";
 import { ProductList } from "@/ui/components/ProductList";
+import { Pagination } from "@/ui/components/Pagination";
 
 export const generateMetadata = async (
 	props: { params: Promise<{ slug: string; channel: string }> },
@@ -22,10 +24,16 @@ export const generateMetadata = async (
 	};
 };
 
-export default async function Page(props: { params: Promise<{ slug: string; channel: string }> }) {
-	const params = await props.params;
+export default async function Page(props: {
+	params: Promise<{ slug: string; channel: string }>;
+	searchParams: Promise<{ cursor?: string; direction?: string }>;
+}) {
+	const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
+
+	const paginationVars = getPaginatedListVariables({ params: searchParams, pageSize: 24 });
+
 	const { category } = await executeGraphQL(ProductListByCategoryDocument, {
-		variables: { slug: params.slug, channel: params.channel },
+		variables: { slug: params.slug, channel: params.channel, ...paginationVars },
 		revalidate: 60,
 	});
 
@@ -38,7 +46,11 @@ export default async function Page(props: { params: Promise<{ slug: string; chan
 	return (
 		<div className="mx-auto max-w-7xl p-8 pb-16">
 			<h1 className="pb-8 text-xl font-semibold">{name}</h1>
+			{products.totalCount != null && (
+				<p className="pb-4 text-sm text-neutral-500">{products.totalCount} products</p>
+			)}
 			<ProductList products={products.edges.map((e) => e.node)} />
+			<Pagination pageInfo={products.pageInfo} />
 		</div>
 	);
 }

--- a/storefront/src/app/[channel]/(main)/products/[slug]/page.tsx
+++ b/storefront/src/app/[channel]/(main)/products/[slug]/page.tsx
@@ -10,11 +10,11 @@ import { EssentialCardInfo } from "@/ui/components/EssentialCardInfo";
 import { MTGCardAttributes } from "@/ui/components/MTGCardAttributes";
 import { executeGraphQL } from "@/lib/graphql";
 import { formatMoney, formatMoneyRange } from "@/lib/utils";
-import { CheckoutAddLineDocument, ProductDetailsDocument, ProductListDocument, OtherPrintingsDocument, RelatedProductsDocument } from "@/gql/graphql";
+import { CheckoutAddLineDocument, ProductDetailsDocument, ProductListDocument } from "@/gql/graphql";
 import * as Checkout from "@/lib/checkout";
 import { AvailabilityMessage } from "@/ui/components/AvailabilityMessage";
-import { OtherPrintings } from "@/ui/components/OtherPrintings";
-import { RelatedProductsCarousel } from "@/ui/components/RelatedProductsCarousel";
+import { LazyOtherPrintings } from "@/ui/components/LazyOtherPrintings";
+import { LazyRelatedProducts } from "@/ui/components/LazyRelatedProducts";
 
 export const dynamic = "force-dynamic";
 
@@ -101,38 +101,6 @@ export default async function Page(props: {
 	if (!product) {
 		notFound();
 	}
-
-	// Fetch other printings and related products in parallel (both depend on product, not each other)
-	const [{ products: otherPrintingsResult }, relatedProducts] = await Promise.all([
-		executeGraphQL(OtherPrintingsDocument, {
-			variables: {
-				search: product.name,
-				channel: params.channel,
-				first: 50,
-			},
-			revalidate: 60,
-		}),
-		product.category?.id
-			? executeGraphQL(RelatedProductsDocument, {
-					variables: {
-						channel: params.channel,
-						categoryId: product.category.id,
-						first: 12,
-					},
-					revalidate: 60,
-				})
-			: Promise.resolve(null),
-	]);
-
-	// Filter to exact name matches only
-	const otherPrintings = otherPrintingsResult?.edges
-		.map((e) => e.node)
-		.filter((p) => p.name === product.name) ?? [];
-
-	// Filter out the current product from related products
-	const filteredRelatedProducts = relatedProducts?.products?.edges
-		.map((e) => e.node)
-		.filter((p) => p.id !== product.id) ?? [];
 
 	// Prefer media URL (external images) over thumbnail URL (Saleor-generated)
 	const firstImage = product.media?.[0] || product.thumbnail;
@@ -300,14 +268,12 @@ export default async function Page(props: {
 						/>
 					</div>
 
-					{/* Other printings of this card */}
-					{otherPrintings.length > 1 && (
-						<OtherPrintings
-							printings={otherPrintings}
-							currentProductId={product.id}
-							channel={params.channel}
-						/>
-					)}
+					{/* Other printings of this card (loaded client-side) */}
+					<LazyOtherPrintings
+						productName={product.name}
+						currentProductId={product.id}
+						channel={params.channel}
+					/>
 				</div>
 			</div>
 
@@ -318,11 +284,13 @@ export default async function Page(props: {
 				</div>
 			)}
 
-			{/* Related Products Carousel */}
-			{filteredRelatedProducts.length > 0 && (
-				<RelatedProductsCarousel
-					products={filteredRelatedProducts}
-					title={product.category?.name ? `More from ${product.category.name}` : "Related Products"}
+			{/* Related Products Carousel (loaded client-side) */}
+			{product.category?.id && (
+				<LazyRelatedProducts
+					categoryId={product.category.id}
+					categoryName={product.category.name ?? undefined}
+					productId={product.id}
+					channel={params.channel}
 				/>
 			)}
 		</section>

--- a/storefront/src/app/api/products/other-printings/route.ts
+++ b/storefront/src/app/api/products/other-printings/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { executeGraphQL } from "@/lib/graphql";
+import { OtherPrintingsDocument } from "@/gql/graphql";
+
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const channel = url.searchParams.get("channel");
+	const productName = url.searchParams.get("productName");
+
+	if (!channel || !productName) {
+		return NextResponse.json(
+			{ error: "Missing required parameters: channel, productName" },
+			{ status: 400 },
+		);
+	}
+
+	try {
+		const result = await executeGraphQL(OtherPrintingsDocument, {
+			variables: {
+				search: productName,
+				channel,
+				first: 50,
+			},
+			revalidate: 60,
+		});
+
+		// Filter to exact name matches only (GraphQL search is fuzzy)
+		const printings =
+			result.products?.edges
+				.map((e) => e.node)
+				.filter((p) => p.name === productName) ?? [];
+
+		return NextResponse.json({ printings });
+	} catch (error) {
+		console.error("[API] Other printings error:", error);
+		return NextResponse.json({ error: "Failed to fetch other printings" }, { status: 500 });
+	}
+}

--- a/storefront/src/app/api/products/related/route.ts
+++ b/storefront/src/app/api/products/related/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { executeGraphQL } from "@/lib/graphql";
+import { RelatedProductsDocument } from "@/gql/graphql";
+
+export async function GET(request: Request) {
+	const url = new URL(request.url);
+	const channel = url.searchParams.get("channel");
+	const categoryId = url.searchParams.get("categoryId");
+	const excludeProductId = url.searchParams.get("excludeProductId");
+
+	if (!channel || !categoryId) {
+		return NextResponse.json(
+			{ error: "Missing required parameters: channel, categoryId" },
+			{ status: 400 },
+		);
+	}
+
+	try {
+		const result = await executeGraphQL(RelatedProductsDocument, {
+			variables: {
+				channel,
+				categoryId,
+				first: 12,
+			},
+			revalidate: 60,
+		});
+
+		const products =
+			result.products?.edges
+				.map((e) => e.node)
+				.filter((p) => p.id !== excludeProductId) ?? [];
+
+		return NextResponse.json({ products });
+	} catch (error) {
+		console.error("[API] Related products error:", error);
+		return NextResponse.json({ error: "Failed to fetch related products" }, { status: 500 });
+	}
+}

--- a/storefront/src/graphql/ProductListByCategory.graphql
+++ b/storefront/src/graphql/ProductListByCategory.graphql
@@ -1,15 +1,29 @@
-query ProductListByCategory($slug: String!, $channel: String!) {
+query ProductListByCategory(
+	$slug: String!
+	$channel: String!
+	$first: Int = 24
+	$after: String
+	$last: Int
+	$before: String
+) {
 	category(slug: $slug) {
 		name
 		description
 		seoDescription
 		seoTitle
-		products(first: 100, channel: $channel) {
+		products(first: $first, after: $after, last: $last, before: $before, channel: $channel) {
 			edges {
 				node {
 					...ProductListItem
 				}
 			}
+			pageInfo {
+				hasNextPage
+				hasPreviousPage
+				startCursor
+				endCursor
+			}
+			totalCount
 		}
 	}
 }

--- a/storefront/src/graphql/ProductListByCollection.graphql
+++ b/storefront/src/graphql/ProductListByCollection.graphql
@@ -1,15 +1,29 @@
-query ProductListByCollection($slug: String!, $channel: String!, $first: Int = 100) {
+query ProductListByCollection(
+	$slug: String!
+	$channel: String!
+	$first: Int = 24
+	$after: String
+	$last: Int
+	$before: String
+) {
 	collection(slug: $slug, channel: $channel) {
 		name
 		description
 		seoDescription
 		seoTitle
-		products(first: $first) {
+		products(first: $first, after: $after, last: $last, before: $before) {
 			edges {
 				node {
 					...ProductListItem
 				}
 			}
+			pageInfo {
+				hasNextPage
+				hasPreviousPage
+				startCursor
+				endCursor
+			}
+			totalCount
 		}
 	}
 }

--- a/storefront/src/lib/utils.ts
+++ b/storefront/src/lib/utils.ts
@@ -57,13 +57,15 @@ export type PaginatedListVariables = {
 
 export const getPaginatedListVariables = ({
 	params,
+	pageSize = ProductsPerPage,
 }: {
 	params: { [key: string]: unknown };
+	pageSize?: number;
 }): PaginatedListVariables => {
 	const cursor = typeof params?.cursor === "string" ? params?.cursor : null;
 	const direction = params?.direction === "prev" ? "prev" : "next";
 
 	return direction === "prev"
-		? { last: ProductsPerPage, before: cursor }
-		: { first: ProductsPerPage, after: cursor };
+		? { last: pageSize, before: cursor }
+		: { first: pageSize, after: cursor };
 };

--- a/storefront/src/middleware.ts
+++ b/storefront/src/middleware.ts
@@ -97,7 +97,17 @@ export function middleware(request: NextRequest) {
   // Cache-Control: cache catalog pages, skip auth/transactional routes
   const isDynamic = DYNAMIC_PATHS.some((p) => pathname.startsWith(p));
   if (!isDynamic && !pathname.startsWith("/api")) {
-    response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=300");
+    // Longer cache for stable catalog pages (sets, categories, board-games)
+    const isStableCatalog =
+      /\/magic\/sets(\/|$)/.test(pathname) ||
+      /\/categories\//.test(pathname) ||
+      /\/board-games\//.test(pathname);
+
+    if (isStableCatalog) {
+      response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=300");
+    } else {
+      response.headers.set("Cache-Control", "public, s-maxage=60, stale-while-revalidate=300");
+    }
   }
 
   return response;

--- a/storefront/src/ui/components/LazyOtherPrintings.tsx
+++ b/storefront/src/ui/components/LazyOtherPrintings.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { OtherPrintings } from "./OtherPrintings";
+import type { OtherPrintingsQuery } from "@/gql/graphql";
+
+type PrintingProduct = NonNullable<OtherPrintingsQuery["products"]>["edges"][number]["node"];
+
+interface LazyOtherPrintingsProps {
+	productName: string;
+	currentProductId: string;
+	channel: string;
+}
+
+export function LazyOtherPrintings({
+	productName,
+	currentProductId,
+	channel,
+}: LazyOtherPrintingsProps) {
+	const [printings, setPrintings] = useState<PrintingProduct[] | null>(null);
+
+	useEffect(() => {
+		const controller = new AbortController();
+		const params = new URLSearchParams({
+			channel,
+			productName,
+		});
+
+		fetch(`/api/products/other-printings?${params}`, { signal: controller.signal })
+			.then((res) => {
+				if (!res.ok) throw new Error(res.statusText);
+				return res.json() as Promise<{ printings?: PrintingProduct[] }>;
+			})
+			.then((data) => setPrintings(data.printings ?? []))
+			.catch((err) => {
+				if (err.name !== "AbortError") setPrintings([]);
+			});
+
+		return () => controller.abort();
+	}, [channel, productName, currentProductId]);
+
+	if (printings === null) {
+		// Skeleton placeholder matching OtherPrintings layout
+		return (
+			<div className="mt-8 border-t border-neutral-100 pt-6">
+				<div className="mb-3 h-4 w-32 animate-pulse rounded bg-neutral-200" />
+				<div className="flex flex-wrap gap-2">
+					{Array.from({ length: 4 }).map((_, i) => (
+						<div
+							key={i}
+							className="h-12 w-24 animate-pulse rounded-lg bg-neutral-200"
+						/>
+					))}
+				</div>
+			</div>
+		);
+	}
+
+	if (printings.length <= 1) {
+		return null;
+	}
+
+	return (
+		<OtherPrintings
+			printings={printings}
+			currentProductId={currentProductId}
+			channel={channel}
+		/>
+	);
+}

--- a/storefront/src/ui/components/LazyRelatedProducts.tsx
+++ b/storefront/src/ui/components/LazyRelatedProducts.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { RelatedProductsCarousel } from "./RelatedProductsCarousel";
+import type { ProductListItemFragment } from "@/gql/graphql";
+
+interface LazyRelatedProductsProps {
+	categoryId: string;
+	categoryName?: string;
+	productId: string;
+	channel: string;
+}
+
+export function LazyRelatedProducts({
+	categoryId,
+	categoryName,
+	productId,
+	channel,
+}: LazyRelatedProductsProps) {
+	const [products, setProducts] = useState<ProductListItemFragment[] | null>(null);
+
+	useEffect(() => {
+		const controller = new AbortController();
+		const params = new URLSearchParams({
+			channel,
+			categoryId,
+			excludeProductId: productId,
+		});
+
+		fetch(`/api/products/related?${params}`, { signal: controller.signal })
+			.then((res) => {
+				if (!res.ok) throw new Error(res.statusText);
+				return res.json() as Promise<{ products?: ProductListItemFragment[] }>;
+			})
+			.then((data) => setProducts(data.products ?? []))
+			.catch((err) => {
+				if (err.name !== "AbortError") setProducts([]);
+			});
+
+		return () => controller.abort();
+	}, [channel, categoryId, productId]);
+
+	if (products === null) {
+		// Skeleton placeholder
+		return (
+			<section className="mt-12 border-t border-neutral-100 pt-8">
+				<div className="mb-6 h-7 w-48 animate-pulse rounded bg-neutral-200" />
+				<div className="flex gap-4 overflow-hidden">
+					{Array.from({ length: 6 }).map((_, i) => (
+						<div key={i} className="w-[200px] flex-shrink-0">
+							<div className="aspect-[2/3] animate-pulse rounded-lg bg-neutral-200" />
+							<div className="mt-2 h-4 w-3/4 animate-pulse rounded bg-neutral-200" />
+							<div className="mt-1 h-4 w-1/2 animate-pulse rounded bg-neutral-200" />
+						</div>
+					))}
+				</div>
+			</section>
+		);
+	}
+
+	if (products.length === 0) {
+		return null;
+	}
+
+	return (
+		<RelatedProductsCarousel
+			products={products}
+			title={categoryName ? `More from ${categoryName}` : "Related Products"}
+		/>
+	);
+}


### PR DESCRIPTION
## Summary

- **Tier 1A — Lazy loading (~2s off product detail TTFB):** Move RelatedProducts and OtherPrintings GraphQL queries out of product detail page SSR into client-side API route handlers with skeleton placeholders
- **Tier 1B — Pagination (~75% less resolver work):** Add cursor-based pagination to ProductListByCategory/Collection queries (first:100 → first:24), add Pagination component to category and board-games pages
- **Tier 2 — Cache tuning (5x fewer origin hits):** Increase s-maxage to 300s for stable catalog pages (sets, categories, board-games)

## Changes

| File | Change |
|------|--------|
| `storefront/src/app/api/products/related/route.ts` | New API route for related products |
| `storefront/src/app/api/products/other-printings/route.ts` | New API route for other printings |
| `storefront/src/ui/components/LazyRelatedProducts.tsx` | Client-side lazy loader with skeleton |
| `storefront/src/ui/components/LazyOtherPrintings.tsx` | Client-side lazy loader with skeleton |
| `storefront/src/app/[channel]/(main)/products/[slug]/page.tsx` | Remove SSR queries, use lazy components |
| `storefront/src/app/[channel]/(main)/categories/[slug]/page.tsx` | Add pagination (first:24) |
| `storefront/src/app/[channel]/(main)/board-games/[category]/page.tsx` | Add pagination (first:24) |
| `storefront/src/graphql/ProductListByCategory.graphql` | Add cursor vars + pageInfo + totalCount |
| `storefront/src/graphql/ProductListByCollection.graphql` | Add cursor vars + pageInfo + totalCount |
| `storefront/src/lib/utils.ts` | Add pageSize param to getPaginatedListVariables |
| `storefront/src/middleware.ts` | Longer s-maxage for stable catalog pages |

## Test plan

- [ ] Product detail page loads without SSR delay — RelatedProducts/OtherPrintings appear after initial paint
- [ ] Skeleton placeholders display while lazy sections load
- [ ] Category pages show 24 products with working Previous/Next pagination
- [ ] Board games category pages show pagination
- [ ] TypeScript compilation passes (verified locally)
- [ ] No regression in variant selector, cart, or checkout
- [ ] Set icon row still displays on product cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)