### PR TITLE
perf: optimistic cart and color identity placeholders (Phase 3)

### DIFF
--- a/storefront/src/app/[channel]/(main)/cart/QuantityEditor.tsx
+++ b/storefront/src/app/[channel]/(main)/cart/QuantityEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useOptimistic, useTransition } from "react";
 import { updateLineQuantity, deleteLineFromCheckout } from "./actions";
 
 type Props = {
@@ -12,20 +12,33 @@ type Props = {
 
 export const QuantityEditor = ({ checkoutId, lineId, variantId, quantity }: Props) => {
 	const [isPending, startTransition] = useTransition();
+	const [optimisticQuantity, setOptimisticQuantity] = useOptimistic(quantity);
 
 	const handleDecrement = () => {
 		if (isPending) return;
-		if (quantity <= 1) {
+		if (optimisticQuantity <= 1) {
+			setOptimisticQuantity(0);
 			startTransition(() => deleteLineFromCheckout({ checkoutId, lineId }));
 		} else {
-			startTransition(() => updateLineQuantity({ checkoutId, variantId, quantity: quantity - 1 }));
+			const newQty = optimisticQuantity - 1;
+			setOptimisticQuantity(newQty);
+			startTransition(() => updateLineQuantity({ checkoutId, variantId, quantity: newQty }));
 		}
 	};
 
 	const handleIncrement = () => {
 		if (isPending) return;
-		startTransition(() => updateLineQuantity({ checkoutId, variantId, quantity: quantity + 1 }));
+		const newQty = optimisticQuantity + 1;
+		setOptimisticQuantity(newQty);
+		startTransition(() => updateLineQuantity({ checkoutId, variantId, quantity: newQty }));
 	};
+
+	// Hide during optimistic delete (quantity reaches 0)
+	if (optimisticQuantity === 0) {
+		return (
+			<span className="text-sm text-neutral-400">Removing...</span>
+		);
+	}
 
 	return (
 		<div className="flex items-center gap-2">
@@ -34,14 +47,14 @@ export const QuantityEditor = ({ checkoutId, lineId, variantId, quantity }: Prop
 				onClick={handleDecrement}
 				disabled={isPending}
 				className="flex h-8 w-8 items-center justify-center rounded border border-neutral-300 text-neutral-600 hover:bg-neutral-100 disabled:opacity-50"
-				aria-label={quantity <= 1 ? "Remove item" : "Decrease quantity"}
+				aria-label={optimisticQuantity <= 1 ? "Remove item" : "Decrease quantity"}
 			>
 				<svg width="16" height="16" viewBox="0 0 24 24" fill="none">
 					<path d="M17 12L7 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
 				</svg>
 			</button>
-			<span className="w-8 text-center font-medium" aria-label={`Quantity: ${quantity}`}>
-				{isPending ? "..." : quantity}
+			<span className="w-8 text-center font-medium" aria-label={`Quantity: ${optimisticQuantity}`}>
+				{optimisticQuantity}
 			</span>
 			<button
 				type="button"

--- a/storefront/src/ui/atoms/ProductImageWrapper.tsx
+++ b/storefront/src/ui/atoms/ProductImageWrapper.tsx
@@ -4,17 +4,37 @@ import NextImage, { type ImageProps } from "next/image";
 import { ImageIcon } from "lucide-react";
 import { useImageFallback } from "@/ui/hooks/useImageFallback";
 
+/**
+ * Map MTG color identity values to subtle background tints for loading placeholders.
+ * Shows a hint of the card's color while the image loads, improving perceived performance.
+ */
+const COLOR_IDENTITY_BG: Record<string, string> = {
+	"mtg-color-w": "#f5f0e1", // White — warm cream
+	"mtg-color-u": "#dce6f0", // Blue — light sky
+	"mtg-color-b": "#d8d4d0", // Black — warm gray
+	"mtg-color-r": "#f0dbd4", // Red — light salmon
+	"mtg-color-g": "#d6e6d4", // Green — light sage
+};
+
+function getPlaceholderColor(colorIdentity?: string[]): string {
+	if (!colorIdentity || colorIdentity.length === 0) return "#f5f5f5";
+	if (colorIdentity.length > 1) return "#ede4d0"; // Multicolor — gold tint
+	return COLOR_IDENTITY_BG[colorIdentity[0]] || "#f5f5f5";
+}
+
 type ProductImageWrapperProps = Omit<ImageProps, "src"> & {
 	src: string;
 	fallbackSrc?: string;
+	colorIdentity?: string[];
 };
 
-export const ProductImageWrapper = ({ src, fallbackSrc, ...props }: ProductImageWrapperProps) => {
+export const ProductImageWrapper = ({ src, fallbackSrc, colorIdentity, ...props }: ProductImageWrapperProps) => {
 	const { src: resolvedSrc, onError, hasError } = useImageFallback(src, fallbackSrc);
+	const placeholderBg = getPlaceholderColor(colorIdentity);
 
 	return (
 		<div className="aspect-square overflow-hidden rounded-lg border border-neutral-100 bg-neutral-50 shadow-sm">
-			<div className="relative h-full w-full animate-pulse bg-neutral-100">
+			<div className="relative h-full w-full animate-pulse" style={{ backgroundColor: placeholderBg }}>
 				{hasError || !resolvedSrc ? (
 					<div className="flex h-full w-full items-center justify-center">
 						<ImageIcon className="h-16 w-16 text-neutral-300" />

--- a/storefront/src/ui/components/ProductElement.tsx
+++ b/storefront/src/ui/components/ProductElement.tsx
@@ -43,6 +43,10 @@ export function ProductElement({
 	const setCode = getAttributeValue(product, "mtg-set-code");
 	const setName = getAttributeValue(product, "mtg-set-name");
 	const rarity = getAttributeValue(product, "mtg-rarity");
+	const colorIdentity = product.attributes
+		?.find((a) => a.attribute.slug === "mtg-color-identity")
+		?.values.map((v) => v.slug)
+		.filter(Boolean) as string[] | undefined;
 	const quantity = getTotalQuantity(product);
 	const isOutOfStock = quantity === 0;
 
@@ -59,6 +63,7 @@ export function ProductElement({
 							height={680}
 							sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 256px"
 							priority={priority}
+							colorIdentity={colorIdentity}
 						/>
 					) : (
 						<div className="flex aspect-square items-center justify-center rounded-lg bg-neutral-100">


### PR DESCRIPTION
## Summary

Phase 3 of the storefront speed implementation plan — optimistic UI updates and color-aware image placeholders.

## Changes

### Optimistic Cart Quantities
- **Modified** `QuantityEditor.tsx` — replace `useTransition` "..." pending with `useOptimistic` from React 19
- Quantity changes appear **instantly** — no more waiting for server round-trip
- Delete-at-zero preserved: decrementing from 1 shows "Removing..." optimistically
- Auto-reverts on server failure (React 19 built-in behavior)
- Server Actions already in place (`cart/actions.ts` is `"use server"`)

### Color Identity Image Placeholders
- **Modified** `ProductImageWrapper.tsx` — accepts optional `colorIdentity` prop, maps WUBRG to subtle background tints
- **Modified** `ProductElement.tsx` — extracts `mtg-color-identity` attribute values and passes to wrapper
- White cards → cream, Blue → sky, Black → warm gray, Red → salmon, Green → sage, Multicolor → gold
- Uses existing `ProductListItem` fragment attribute data — **zero additional API calls**
- Replaces generic gray shimmer with color-appropriate placeholder during image load

## Test plan

- [ ] Cart: increment/decrement shows new quantity instantly (no "..." delay)
- [ ] Cart: decrement from 1 shows "Removing..." then item disappears
- [ ] Cart: if server fails (network off), quantity reverts to original value
- [ ] Product grid: colored cards show tinted placeholder before image loads
- [ ] Product grid: colorless/artifact cards show default gray placeholder
- [ ] Product grid: multicolor cards show gold tint
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)