### PR TITLE
fix: product page CLS 0.731 and search redundant health check

### DIFF
--- a/storefront/src/app/[channel]/(main)/products/[slug]/page.tsx
+++ b/storefront/src/app/[channel]/(main)/products/[slug]/page.tsx
@@ -217,18 +217,22 @@ export default async function Page(props: {
 				}}
 			/>
 			<div className="lg:flex lg:gap-12">
-				{/* Product Image */}
-				<div className="lg:w-[45%] lg:flex-shrink-0">
-					{firstImage && (
+				{/* Product Image — aspect-square reserves space to prevent CLS */}
+				<div className="aspect-square lg:w-[45%] lg:flex-shrink-0">
+					{firstImage ? (
 						<ProductImageWrapper
 							priority={true}
 							alt={firstImage.alt ?? ""}
 							width={672}
-							height={936}
+							height={672}
 							sizes="(max-width: 1024px) 100vw, 45vw"
 							src={firstImage.url}
 							fallbackSrc={fallbackImageUrl}
 						/>
+					) : (
+						<div className="flex h-full w-full items-center justify-center rounded-lg border border-neutral-100 bg-neutral-50">
+							<span className="text-neutral-300">No image</span>
+						</div>
 					)}
 				</div>
 

--- a/storefront/src/app/[channel]/(main)/search/actions.ts
+++ b/storefront/src/app/[channel]/(main)/search/actions.ts
@@ -6,6 +6,9 @@ import {
 	type MeilisearchProduct,
 	type SearchFilters,
 } from "@/lib/meilisearch";
+// Note: isMeilisearchHealthy is used by checkMeilisearchHealth() export below.
+// The page.tsx caller checks health before calling searchWebstore, so searchWebstore
+// no longer checks health internally (removed redundant double-check).
 
 export interface WebstoreSearchResult {
 	products: MeilisearchProduct[];
@@ -48,18 +51,6 @@ export async function searchWebstore(
 	} = {},
 ): Promise<WebstoreSearchResult> {
 	const { limit = 50, offset = 0, filters = {}, sort } = options;
-
-	// Check Meilisearch health first
-	const isHealthy = await isMeilisearchHealthy();
-	if (!isHealthy) {
-		console.warn("Meilisearch is not available, returning empty results");
-		return {
-			products: [],
-			totalCount: 0,
-			hasNextPage: false,
-			processingTimeMs: 0,
-		};
-	}
 
 	// Build Meilisearch filters
 	const meilisearchFilters: SearchFilters = {};


### PR DESCRIPTION
## Summary

Fixes two issues discovered during Lighthouse benchmarking (baseline 2026-03-14):

1. **Product page CLS 0.731** (catastrophic layout shift) — image container lacked explicit aspect ratio reservation on the outer div, causing full-page reflow when images loaded
2. **Search page redundant health check** — `searchWebstore()` called `isMeilisearchHealthy()` even though the page already checked health before calling it, wasting a network round-trip per search

## Changes

### Product Page CLS Fix
- Add `aspect-square` to image container outer div to reserve space before image loads
- Change image height prop from 936 to 672 to match square container (eliminates intrinsic size mismatch)
- Replace conditional `{firstImage && (` with ternary that always renders a placeholder — prevents layout shift from absent-then-present image block

### Search Performance
- Remove redundant `isMeilisearchHealthy()` inside `searchWebstore()` — caller already gates on health check result
- Saves one fetch round-trip per search request

## Test plan

- [ ] Product page: no visible layout jump when image loads
- [ ] Product page: image displays correctly in square container
- [ ] Product page: "No image" placeholder shows for products without images
- [ ] Search: results still load correctly via Meilisearch
- [ ] Search: GraphQL fallback still works when Meilisearch is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)