### PR TITLE
feat: search typeahead and webhook cache revalidation (Phase 4)

### DIFF
--- a/storefront/src/app/api/revalidate/route.ts
+++ b/storefront/src/app/api/revalidate/route.ts
@@ -1,0 +1,77 @@
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Saleor webhook handler for on-demand cache revalidation.
+ *
+ * Invalidates Next.js Data Cache entries tagged with relevant product/category IDs.
+ * Saleor 3.22 uses JWS (JSON Web Signature) for payload signing — full JWS
+ * verification requires the JWKS endpoint and is deferred to a follow-up.
+ * For now, this endpoint relies on network-level security (not publicly routed
+ * on staging) and a shared secret token in the query string.
+ *
+ * Note: With force-dynamic on all pages, this only benefits the fetch-level
+ * Data Cache (revalidate: 60 on executeGraphQL calls). Full page-level
+ * caching benefits unlock after PPR migration (Phase 5.1).
+ */
+export async function POST(req: NextRequest) {
+	// Simple shared-secret auth until JWS verification is implemented
+	const token = req.nextUrl.searchParams.get("token");
+	const expectedToken = process.env.SALEOR_WEBHOOK_SECRET;
+	if (expectedToken && token !== expectedToken) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const rawBody = await req.text();
+
+	type WebhookBody = {
+		product?: { id?: string };
+		// Saleor sends camelCase in webhook payloads
+		productVariant?: { product?: { id?: string } };
+		category?: { id?: string };
+	};
+
+	let body: WebhookBody;
+	try {
+		body = JSON.parse(rawBody) as WebhookBody;
+	} catch {
+		return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+	}
+
+	// Saleor sends event type in Saleor-Event header (case-insensitive via Headers API)
+	const event = req.headers.get("saleor-event");
+	const revalidatedTags: string[] = [];
+
+	function invalidate(tag: string) {
+		revalidateTag(tag, "default");
+		revalidatedTags.push(tag);
+	}
+
+	switch (event) {
+		case "PRODUCT_UPDATED":
+		case "PRODUCT_CREATED":
+		case "PRODUCT_DELETED": {
+			if (body.product?.id) invalidate(`product-${body.product.id}`);
+			invalidate("products");
+			break;
+		}
+		case "PRODUCT_VARIANT_UPDATED":
+		case "PRODUCT_VARIANT_CREATED":
+		case "PRODUCT_VARIANT_DELETED": {
+			if (body.productVariant?.product?.id) invalidate(`product-${body.productVariant.product.id}`);
+			invalidate("products");
+			break;
+		}
+		case "CATEGORY_UPDATED":
+		case "CATEGORY_CREATED":
+		case "CATEGORY_DELETED": {
+			if (body.category?.id) invalidate(`category-${body.category.id}`);
+			invalidate("categories");
+			break;
+		}
+		default:
+			return NextResponse.json({ revalidated: false, event, reason: "unhandled event type" });
+	}
+
+	return NextResponse.json({ revalidated: true, event, tags: revalidatedTags });
+}

--- a/storefront/src/app/api/search/suggestions/route.ts
+++ b/storefront/src/app/api/search/suggestions/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const MEILISEARCH_URL = process.env.MEILISEARCH_URL || "http://localhost:7700";
+const MEILISEARCH_API_KEY = process.env.MEILISEARCH_API_KEY;
+
+/**
+ * Search suggestions endpoint for typeahead.
+ * Returns up to 5 product matches from Meilisearch with minimal fields.
+ * Includes a 3-second timeout to handle Meilisearch reindex freezes.
+ */
+export async function GET(req: NextRequest) {
+	const query = req.nextUrl.searchParams.get("q");
+	const channel = req.nextUrl.searchParams.get("channel") || "webstore";
+
+	if (!query || query.length < 2) {
+		return NextResponse.json({ hits: [] });
+	}
+
+	// Validate channel to prevent path traversal in Meilisearch URL
+	if (!/^[a-z0-9-]+$/.test(channel)) {
+		return NextResponse.json({ hits: [] }, { status: 400 });
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 3000);
+
+	try {
+		const headers: Record<string, string> = { "Content-Type": "application/json" };
+		if (MEILISEARCH_API_KEY) {
+			headers["Authorization"] = `Bearer ${MEILISEARCH_API_KEY}`;
+		}
+
+		const response = await fetch(
+			`${MEILISEARCH_URL}/indexes/${channel}-products/search`,
+			{
+				method: "POST",
+				headers,
+				body: JSON.stringify({
+					q: query,
+					limit: 5,
+					attributesToRetrieve: ["name", "slug", "thumbnail", "min_price", "set_name", "set_code", "rarity"],
+					attributesToHighlight: ["name"],
+					attributesToCrop: [],
+				}),
+				signal: controller.signal,
+			},
+		);
+
+		clearTimeout(timeout);
+
+		if (!response.ok) {
+			return NextResponse.json({ hits: [] }, { status: 503 });
+		}
+
+		const data = (await response.json()) as { hits?: unknown[]; processingTimeMs?: number };
+		return NextResponse.json({
+			hits: data.hits || [],
+			processingTimeMs: data.processingTimeMs || 0,
+		});
+	} catch {
+		clearTimeout(timeout);
+		return NextResponse.json({ hits: [] }, { status: 503 });
+	}
+}

--- a/storefront/src/lib/graphql.ts
+++ b/storefront/src/lib/graphql.ts
@@ -19,13 +19,14 @@ export async function executeGraphQL<Result, Variables>(
 		headers?: HeadersInit;
 		cache?: RequestCache;
 		revalidate?: number;
+		tags?: string[];
 		withAuth?: boolean;
 	} & (Variables extends Record<string, never> ? { variables?: never } : { variables: Variables }),
 ): Promise<Result> {
 	invariant(process.env.NEXT_PUBLIC_SALEOR_API_URL, "Missing NEXT_PUBLIC_SALEOR_API_URL env variable");
 	// Use server-side URL for server actions (Docker network), fallback to public URL
 	const apiUrl = process.env.SALEOR_API_URL || process.env.NEXT_PUBLIC_SALEOR_API_URL;
-	const { variables, headers, cache, revalidate, withAuth = true } = options;
+	const { variables, headers, cache, revalidate, tags, withAuth = true } = options;
 
 	// Extract operation name from query string for Saleor metrics visibility
 	const query = operation.toString();
@@ -43,7 +44,7 @@ export async function executeGraphQL<Result, Variables>(
 			...(variables && { variables }),
 		}),
 		cache: cache,
-		next: { revalidate },
+		next: { revalidate, tags },
 	};
 
 	const response = await (async () => {

--- a/storefront/src/ui/components/nav/components/SearchBar.tsx
+++ b/storefront/src/ui/components/nav/components/SearchBar.tsx
@@ -1,22 +1,28 @@
 "use client";
 
+import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { SearchIcon } from "lucide-react";
+import { SearchSuggestions } from "./SearchSuggestions";
 
 export const SearchBar = ({ channel }: { channel: string }) => {
 	const router = useRouter();
+	const [query, setQuery] = useState("");
+	const [showSuggestions, setShowSuggestions] = useState(false);
+	const formRef = useRef<HTMLFormElement>(null);
 
 	function onSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const search = formData.get("search") as string;
-		if (search && search.trim().length > 0) {
-			router.push(`/${encodeURIComponent(channel)}/search?query=${encodeURIComponent(search)}`);
+		const trimmed = query.trim();
+		if (trimmed.length > 0) {
+			setShowSuggestions(false);
+			router.push(`/${encodeURIComponent(channel)}/search?query=${encodeURIComponent(trimmed)}`);
 		}
 	}
 
 	return (
 		<form
+			ref={formRef}
 			onSubmit={onSubmit}
 			className="group relative my-2 flex w-full items-center justify-items-center text-sm lg:w-80"
 		>
@@ -26,8 +32,18 @@ export const SearchBar = ({ channel }: { channel: string }) => {
 					type="text"
 					name="search"
 					placeholder="Search for products..."
-					autoComplete="on"
+					autoComplete="off"
 					required
+					value={query}
+					onChange={(e) => {
+						setQuery(e.target.value);
+						setShowSuggestions(true);
+					}}
+					onFocus={() => query.length >= 2 && setShowSuggestions(true)}
+					onBlur={() => {
+						// Delay to allow click on suggestion
+						setTimeout(() => setShowSuggestions(false), 200);
+					}}
 					className="h-10 w-full rounded-md border border-neutral-300 bg-transparent bg-white px-4 py-2 pr-10 text-sm text-black placeholder:text-neutral-500 focus:border-black focus:ring-black"
 				/>
 			</label>
@@ -40,6 +56,16 @@ export const SearchBar = ({ channel }: { channel: string }) => {
 					<SearchIcon aria-hidden className="h-5 w-5" />
 				</button>
 			</div>
+			{showSuggestions && (
+				<SearchSuggestions
+					query={query}
+					channel={channel}
+					onSelect={() => {
+						setShowSuggestions(false);
+						setQuery("");
+					}}
+				/>
+			)}
 		</form>
 	);
 };

--- a/storefront/src/ui/components/nav/components/SearchSuggestions.tsx
+++ b/storefront/src/ui/components/nav/components/SearchSuggestions.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+type Suggestion = {
+	name: string;
+	slug: string;
+	thumbnail?: string | null;
+	min_price?: number | null;
+	set_name?: string | null;
+	set_code?: string | null;
+	rarity?: string | null;
+};
+
+export function SearchSuggestions({
+	query,
+	channel,
+	onSelect,
+}: {
+	query: string;
+	channel: string;
+	onSelect: () => void;
+}) {
+	const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+	const [loading, setLoading] = useState(false);
+	const controllerRef = useRef<AbortController | null>(null);
+
+	useEffect(() => {
+		if (query.length < 2) {
+			setSuggestions([]);
+			return;
+		}
+
+		// Cancel previous request
+		controllerRef.current?.abort();
+		const controller = new AbortController();
+		controllerRef.current = controller;
+
+		setLoading(true);
+
+		const timer = setTimeout(async () => {
+			try {
+				const res = await fetch(
+					`/api/search/suggestions?q=${encodeURIComponent(query)}&channel=${encodeURIComponent(channel)}`,
+					{ signal: controller.signal },
+				);
+				if (!res.ok) {
+					setSuggestions([]);
+					return;
+				}
+				const data = (await res.json()) as { hits?: Suggestion[] };
+				if (!controller.signal.aborted) {
+					setSuggestions(data.hits || []);
+				}
+			} catch {
+				if (!controller.signal.aborted) {
+					setSuggestions([]);
+				}
+			} finally {
+				if (!controller.signal.aborted) {
+					setLoading(false);
+				}
+			}
+		}, 200); // 200ms debounce
+
+		return () => {
+			clearTimeout(timer);
+			controller.abort();
+		};
+	}, [query, channel]);
+
+	if (query.length < 2 || (!loading && suggestions.length === 0)) {
+		return null;
+	}
+
+	return (
+		<div className="absolute left-0 right-0 top-full z-50 mt-1 overflow-hidden rounded-md border border-neutral-200 bg-white shadow-lg">
+			{loading && suggestions.length === 0 ? (
+				<div className="px-4 py-3 text-sm text-neutral-400">Searching...</div>
+			) : (
+				<ul className="divide-y divide-neutral-100">
+					{suggestions.map((hit, i) => (
+						<li key={`${hit.slug}-${i}`}>
+							<Link
+								href={`/${encodeURIComponent(channel)}/products/${hit.slug}`}
+								onClick={onSelect}
+								className="flex items-center gap-3 px-4 py-2 hover:bg-neutral-50"
+							>
+								{hit.thumbnail ? (
+									<Image
+										src={hit.thumbnail}
+										alt=""
+										width={32}
+										height={32}
+										className="h-8 w-8 rounded object-contain"
+										unoptimized
+									/>
+								) : (
+									<div className="h-8 w-8 rounded bg-neutral-100" />
+								)}
+								<div className="min-w-0 flex-1">
+									<p className="truncate text-sm font-medium text-neutral-900">
+										{hit.name}
+									</p>
+									<p className="truncate text-xs text-neutral-500">
+										{hit.set_name}
+										{hit.min_price != null && ` · $${Number(hit.min_price).toFixed(2)}`}
+									</p>
+								</div>
+							</Link>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Phase 4 of the storefront speed implementation plan — instant search suggestions and webhook-driven cache invalidation.

## Changes

### 4.1 Search Typeahead
- **NEW** `/api/search/suggestions` — Meilisearch endpoint with 3s timeout, returns top 5 matches
- **NEW** `SearchSuggestions.tsx` — Dropdown with 200ms debounce, AbortController, product thumbnails
- **Modified** `SearchBar.tsx` — Upgraded from submit-only to typeahead-as-you-type + submit
- Channel param validated with regex to prevent path traversal

### 4.2 Webhook Cache Revalidation
- **NEW** `/api/revalidate` — Saleor webhook handler, calls `revalidateTag()` on product/category events
- **Modified** `graphql.ts` — Added optional `tags` parameter for Data Cache tagging
- Shared-secret auth via query string (JWS verification deferred to follow-up)
- Handles PRODUCT_UPDATED/CREATED/DELETED, PRODUCT_VARIANT_*, CATEGORY_* events

### Security (Codex Review Fixes)
- Channel parameter regex validation against path traversal
- `Number()` cast on `min_price` before `.toFixed()` (crash prevention)
- Index-suffixed keys for duplicate slug safety in suggestions list

## Infrastructure Required (post-merge)
- Add `SALEOR_WEBHOOK_SECRET` to storefront ECS task definition env vars
- Register webhook in Saleor Dashboard targeting `https://staging.michaelbean.org/api/revalidate?token=<secret>`
- Subscribe to: PRODUCT_UPDATED, PRODUCT_CREATED, PRODUCT_DELETED, CATEGORY_UPDATED, PRODUCT_VARIANT_UPDATED

## Test plan

- [ ] Type 2+ characters in search bar → suggestions dropdown appears with product thumbnails
- [ ] Click a suggestion → navigates to product page, dropdown closes
- [ ] Submit search form → navigates to search results page (existing behavior preserved)
- [ ] Fast typing → only last keystroke's results shown (debounce + abort)
- [ ] POST to /api/revalidate with valid event header → returns revalidated tags
- [ ] POST to /api/revalidate without token (when secret set) → returns 401
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)