### PR TITLE
feat: instant navigation progress bar

### DIFF
--- a/storefront/src/app/[channel]/(main)/layout.tsx
+++ b/storefront/src/app/[channel]/(main)/layout.tsx
@@ -1,7 +1,8 @@
-import { type ReactNode } from "react";
+import { type ReactNode, Suspense } from "react";
 import { Footer } from "@/ui/components/Footer";
 import { Header } from "@/ui/components/Header";
 import { CookieConsent } from "@/ui/components/CookieConsent";
+import { NavigationProgress } from "@/ui/components/NavigationProgress";
 
 export const metadata = {
 	title: "Saleor Storefront example",
@@ -16,6 +17,9 @@ export default async function RootLayout(props: {
 
 	return (
 		<>
+			<Suspense>
+				<NavigationProgress />
+			</Suspense>
 			<Header channel={channel} />
 			<div className="flex min-h-[calc(100dvh-64px)] flex-col">
 				<main className="flex-1">{props.children}</main>

--- a/storefront/src/ui/components/NavigationProgress.tsx
+++ b/storefront/src/ui/components/NavigationProgress.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useCallback, useSyncExternalStore } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+/**
+ * Slim top-of-page progress bar that shows during route transitions.
+ * Bridges the perceptual gap between "user clicks link" and "loading.tsx skeleton appears".
+ *
+ * Uses useSyncExternalStore to manage progress state outside React's render cycle,
+ * avoiding setState-in-effect and ref-during-render lint violations.
+ */
+
+type ProgressState = { progress: number; visible: boolean; trackedUrl: string };
+
+let state: ProgressState = { progress: 0, visible: false, trackedUrl: "" };
+const listeners = new Set<() => void>();
+
+function emit() {
+	listeners.forEach((l) => l());
+}
+
+function subscribe(callback: () => void) {
+	listeners.add(callback);
+	return () => listeners.delete(callback);
+}
+
+function getSnapshot(): ProgressState {
+	return state;
+}
+
+let animationInterval: ReturnType<typeof setInterval> | null = null;
+let completionTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function startProgress() {
+	if (completionTimeout) clearTimeout(completionTimeout);
+	if (animationInterval) clearInterval(animationInterval);
+
+	state = { ...state, visible: true, progress: 15 };
+	emit();
+
+	let current = 15;
+	animationInterval = setInterval(() => {
+		current += Math.max(1, (85 - current) * 0.08);
+		if (current >= 85) {
+			current = 85;
+			if (animationInterval) clearInterval(animationInterval);
+			animationInterval = null;
+		}
+		state = { ...state, progress: current };
+		emit();
+	}, 50);
+}
+
+function completeProgress() {
+	if (animationInterval) {
+		clearInterval(animationInterval);
+		animationInterval = null;
+	}
+	state = { ...state, progress: 100 };
+	emit();
+	completionTimeout = setTimeout(() => {
+		state = { ...state, visible: false, progress: 0 };
+		emit();
+		completionTimeout = null;
+	}, 200);
+}
+
+/**
+ * Called when the URL changes. If we were showing the progress bar,
+ * complete it. Update the tracked URL in external state.
+ */
+function onUrlChange(newUrl: string) {
+	if (state.trackedUrl && state.trackedUrl !== newUrl && state.visible) {
+		completeProgress();
+	}
+	state = { ...state, trackedUrl: newUrl };
+	// No emit needed — this is a bookkeeping update, not a render trigger
+}
+
+export function NavigationProgress() {
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const currentState = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+	const currentUrl = pathname + searchParams.toString();
+
+	// Detect URL changes in an effect (not during render)
+	useEffect(() => {
+		onUrlChange(currentUrl);
+	}, [currentUrl]);
+
+	// Intercept all clicks on <a> tags to start the progress bar
+	const handleClick = useCallback(
+		(e: MouseEvent) => {
+			const target = (e.target as HTMLElement).closest("a");
+			if (!target) return;
+
+			const href = target.getAttribute("href");
+			if (!href) return;
+
+			if (href.startsWith("http") || href.startsWith("#") || href.startsWith("mailto:")) return;
+			if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
+			if (target.getAttribute("target") === "_blank") return;
+			if (target.getAttribute("download")) return;
+			if (href === pathname) return;
+
+			startProgress();
+		},
+		[pathname],
+	);
+
+	useEffect(() => {
+		document.addEventListener("click", handleClick, { capture: true });
+		return () => document.removeEventListener("click", handleClick, { capture: true });
+	}, [handleClick]);
+
+	if (!currentState.visible) return null;
+
+	return (
+		<div
+			className="fixed inset-x-0 top-0 z-[9999] h-0.5"
+			role="progressbar"
+			aria-valuenow={Math.round(currentState.progress)}
+			aria-valuemin={0}
+			aria-valuemax={100}
+		>
+			<div
+				className="h-full bg-brand-bright-blue transition-all duration-150 ease-out"
+				style={{ width: `${currentState.progress}%` }}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Adds a slim YouTube/GitHub-style progress bar at the top of the page that fires **immediately** on link click, before Next.js starts the server fetch. Addresses the perceived slowness when navigating between pages (especially homepage → set search pages).

## How it works

1. Document-level click listener intercepts all internal `<a>` clicks
2. Progress bar appears instantly (15%) and animates to ~80% with diminishing increments
3. When the new page renders (pathname/searchParams change), bar completes to 100% and fades
4. Skips external links, hash links, cmd/ctrl clicks, same-page clicks

## Details

- **NEW** `NavigationProgress.tsx` — uses `useSyncExternalStore` to manage progress state outside React render cycle (avoids setState-in-effect and ref-during-render lint violations)
- **Modified** `layout.tsx` — added NavigationProgress wrapped in Suspense
- Uses `brand-bright-blue` color, 2px height, fixed at top with z-9999
- Zero dependencies — pure React hooks + CSS transitions

## Test plan

- [ ] Click any internal link → blue progress bar appears instantly at top
- [ ] Bar animates forward, completes when new page renders
- [ ] External links, cmd+click, hash links do NOT trigger the bar
- [ ] Clicking current page link does NOT trigger the bar
- [ ] `pnpm build` and `pnpm lint` succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)