### PR TITLE
fix: forward Next.js headers through CloudFront

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -27,7 +27,7 @@ feature/* branch → push → PR targeting platform/main → test-platform CI �
 
 1. Create a `feature/*` branch off `platform/main`
 2. Make changes, commit, push the feature branch
-3. Create a PR targeting `platform/main` with the `auto-merge` label
+3. Create a PR targeting `platform/main` with the `automerge` label
 4. `test-platform` CI runs automatically (lint, tests, builds, security)
 5. `auto-merge.yml` fires on `test-platform` completion — squash-merges if all required checks pass
 6. `deploy-staging.yml` triggers on merge to `platform/main` — deploys to AWS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Key extensions live in `saleor-apps/apps/` and integrate tightly with pricing, i
 |------|---------|
 | **Never commit to `main`** | `main` mirrors upstream `saleor/saleor-platform` — exists only for pulling Saleor updates |
 | **PR-first workflow** | All changes go through PRs targeting `platform/main`. Never push directly. See `.claude/rules/git-workflow.md` |
-| **Work on `feature/*` branches** | Create off `platform/main`, merge back via PR with `auto-merge` label |
+| **Work on `feature/*` branches** | Create off `platform/main`, merge back via PR with `automerge` label |
 | **Prefer extension over modification** | Use Saleor Apps, webhooks, workers, env configuration |
 | **Always verify the active branch** | `git branch --show-current` before any changes |
 | **No untracked infrastructure changes** | Manual AWS changes must be logged and reconciled with Terraform |

--- a/infra/terraform/modules/cloudfront-storefront/main.tf
+++ b/infra/terraform/modules/cloudfront-storefront/main.tf
@@ -75,7 +75,13 @@ resource "aws_cloudfront_cache_policy" "dynamic_pages" {
       cookie_behavior = "none"
     }
     headers_config {
-      header_behavior = "none"
+      header_behavior = "whitelist"
+      headers {
+        items = [
+          "RSC",                    # React Server Components — response format differs from HTML
+          "Next-Router-State-Tree", # RSC navigation context
+        ]
+      }
     }
     query_strings_config {
       query_string_behavior = "all" # Forward query strings for search, pagination
@@ -101,7 +107,16 @@ resource "aws_cloudfront_origin_request_policy" "alb_forwarding" {
   headers_config {
     header_behavior = "whitelist"
     headers {
-      items = ["Host", "Accept", "Accept-Language", "Referer"]
+      items = [
+        "Host",
+        "Accept",
+        "Accept-Language",
+        "Referer",
+        "Next-Action",         # Server action ID — without this, Next.js returns HTML instead of action response
+        "Next-Router-State-Tree", # RSC navigation state
+        "RSC",                 # React Server Components request marker
+        "Content-Type",        # POST body content type
+      ]
     }
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: CloudFront origin request policy only forwarded `Host`, `Accept`, `Accept-Language`, `Referer` headers. Next.js server actions require `Next-Action` header to be forwarded — without it, Next.js returns HTML instead of the action payload, causing "An unexpected response was received from the server"
- Added `Next-Action`, `RSC`, `Next-Router-State-Tree`, `Content-Type` to the origin request policy
- Added `RSC`, `Next-Router-State-Tree` to the dynamic pages cache key so CloudFront distinguishes HTML GETs from RSC navigation requests
- Fixed `automerge` label name in CLAUDE.md and git-workflow.md (workflow expects `automerge` not `auto-merge`)

## Test plan
- [x] Terraform applied to staging — CloudFront distribution updated
- [x] Verified add-to-cart works via browser: green "Added to cart!" message, cart badge updated, zero console errors
- [ ] Verify this PR's terraform validation passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)