### PR TITLE
fix: cart page cached empty by CloudFront

### DIFF
--- a/storefront/src/middleware.ts
+++ b/storefront/src/middleware.ts
@@ -95,7 +95,9 @@ export function middleware(request: NextRequest) {
   });
 
   // Cache-Control: cache catalog pages, skip auth/transactional routes
-  const isDynamic = DYNAMIC_PATHS.some((p) => pathname.startsWith(p));
+  // Paths include a channel prefix (e.g., /webstore/cart), so check path segments
+  const segments = pathname.split("/");
+  const isDynamic = DYNAMIC_PATHS.some((p) => segments.some((seg) => `/${seg}` === p));
   if (!isDynamic && !pathname.startsWith("/api")) {
     // Longer cache for stable catalog pages (sets, categories, board-games)
     const isStableCatalog =


### PR DESCRIPTION
## Summary
- **Root cause**: Middleware `DYNAMIC_PATHS` check used `startsWith("/cart")` but actual URLs have a channel prefix (`/webstore/cart`), so the check never matched
- Cart, checkout, login, and orders pages were all getting `Cache-Control: public, s-maxage=60` — CloudFront cached the empty cart page and served it to everyone
- Fix: check path segments instead of `startsWith` to match regardless of channel prefix

## Test plan
- [ ] Navigate to staging, add an item to cart
- [ ] Click the cart icon — cart page should show the item (not empty)
- [ ] Verify `curl -sD- staging.michaelbean.org/webstore/cart` has no `s-maxage` in Cache-Control

🤖 Generated with [Claude Code](https://claude.com/claude-code)