### PR TITLE
fix: extract remaining inline server actions

### DIFF
--- a/storefront/src/app/[channel]/(main)/actions.ts
+++ b/storefront/src/app/[channel]/(main)/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export async function handleSearchAction(formData: FormData) {
+	const search = formData.get("search") as string;
+	const channel = formData.get("channel") as string;
+	if (search && search.trim().length > 0 && channel) {
+		redirect(`/${encodeURIComponent(channel)}/search?query=${encodeURIComponent(search)}`);
+	}
+}

--- a/storefront/src/app/[channel]/(main)/orders/page.tsx
+++ b/storefront/src/app/[channel]/(main)/orders/page.tsx
@@ -3,6 +3,8 @@ import { executeGraphQL } from "@/lib/graphql";
 import { LoginForm } from "@/ui/components/LoginForm";
 import { OrderListItem } from "@/ui/components/OrderListItem";
 
+export const dynamic = "force-dynamic";
+
 export default async function OrderPage() {
 	const { me: user } = await executeGraphQL(CurrentUserOrderListDocument, {
 		cache: "no-cache",

--- a/storefront/src/app/[channel]/(main)/page.tsx
+++ b/storefront/src/app/[channel]/(main)/page.tsx
@@ -1,9 +1,9 @@
-import { redirect } from "next/navigation";
 import Link from "next/link";
 import { SearchIcon, Package, Sparkles, Users, Calendar } from "lucide-react";
 import { ProductList } from "@/ui/components/ProductList";
 import { SetIconImage } from "@/ui/components/SetIconImage";
 import { getLatestSets, getTrendingProducts } from "@/lib/filters";
+import { handleSearchAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -89,14 +89,6 @@ export default async function Page(props: { params: Promise<{ channel: string }>
 		getTrendingProducts(params.channel, 8),
 		getLatestSets(params.channel, 6),
 	]);
-
-	async function handleSearch(formData: FormData) {
-		"use server";
-		const search = formData.get("search") as string;
-		if (search && search.trim().length > 0) {
-			redirect(`/${encodeURIComponent(params.channel)}/search?query=${encodeURIComponent(search)}`);
-		}
-	}
 
 	return (
 		<>
@@ -241,7 +233,8 @@ export default async function Page(props: { params: Promise<{ channel: string }>
 				<div className="mx-auto max-w-3xl px-8 text-center">
 					<h2 className="font-display text-xl font-bold text-neutral-900">Find Your Cards</h2>
 					<p className="mt-2 text-neutral-600">Search over 100,000 Magic: The Gathering cards</p>
-					<form action={handleSearch} className="mx-auto mt-6 max-w-xl">
+					<form action={handleSearchAction} className="mx-auto mt-6 max-w-xl">
+						<input type="hidden" name="channel" value={params.channel} />
 						<div className="relative">
 							<input
 								type="text"

--- a/storefront/src/ui/components/LoginForm.tsx
+++ b/storefront/src/ui/components/LoginForm.tsx
@@ -1,32 +1,13 @@
-import { redirect } from "next/navigation";
-import { getServerAuthClient } from "@/app/config";
+import { loginAction } from "./login-actions";
 
 export async function LoginForm({ redirectTo = "/" }: { redirectTo?: string }) {
 	return (
 		<div className="mx-auto mt-16 w-full max-w-lg">
 			<form
 				className="rounded border p-8 shadow-md"
-				action={async (formData) => {
-					"use server";
-
-					const email = formData.get("email")?.toString();
-					const password = formData.get("password")?.toString();
-
-					if (!email || !password) {
-						throw new Error("Email and password are required");
-					}
-
-					const { data } = await (
-						await getServerAuthClient()
-					).signIn({ email, password }, { cache: "no-store" });
-
-					if (data.tokenCreate.errors.length > 0) {
-						throw new Error(data.tokenCreate.errors.map((e) => e.message).join(", "));
-					}
-
-					redirect(redirectTo);
-				}}
+				action={loginAction}
 			>
+				<input type="hidden" name="redirectTo" value={redirectTo} />
 				<div className="mb-2">
 					<label className="sr-only" htmlFor="email">
 						Email

--- a/storefront/src/ui/components/login-actions.ts
+++ b/storefront/src/ui/components/login-actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { getServerAuthClient } from "@/app/config";
+
+export async function loginAction(formData: FormData) {
+	const email = formData.get("email")?.toString();
+	const password = formData.get("password")?.toString();
+	const redirectTo = formData.get("redirectTo")?.toString() || "/";
+
+	if (!email || !password) {
+		throw new Error("Email and password are required");
+	}
+
+	const { data } = await (
+		await getServerAuthClient()
+	).signIn({ email, password }, { cache: "no-store" });
+
+	if (data.tokenCreate.errors.length > 0) {
+		throw new Error(data.tokenCreate.errors.map((e) => e.message).join(", "));
+	}
+
+	redirect(redirectTo);
+}


### PR DESCRIPTION
## Summary
- **LoginForm**: Inline `"use server"` closure extracted to `login-actions.ts`. Uses hidden form field for `redirectTo` instead of closure.
- **Homepage search**: Inline `handleSearch` closure extracted to `actions.ts`. Uses hidden field for `channel`.
- **Orders page**: Added `force-dynamic` — renders user-specific data, must not be cached by CloudFront.

These are the remaining inline server actions identified by a full storefront CloudFront compatibility audit. All other server actions already use stable top-level exports.

## Red team analysis
Findings 4-10 from the audit were evaluated and dismissed:
- isDynamic segment matching: exact equality prevents false positives
- Revalidate webhook: only purges cache, no data exposure
- Search suggestions caching: middleware already excludes `/api` paths
- CSP connect-src: `'self'` covers all relative fetches
- Cookie secure flag: `NEXT_PUBLIC_STOREFRONT_URL` is set to HTTPS on staging

## Test plan
- [ ] Login form works after redeployment (no "Server Action not found")
- [ ] Homepage search form submits correctly
- [ ] Orders page not cached by CloudFront (verify no `s-maxage` header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)