### PR TITLE
fix: move variant redirect to page level, fix blank product pages

### DIFF
--- a/storefront/src/app/[channel]/(main)/actions.ts
+++ b/storefront/src/app/[channel]/(main)/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export async function handleSearchAction(formData: FormData) {
+	const search = formData.get("search") as string;
+	const channel = formData.get("channel") as string;
+	if (search && search.trim().length > 0 && channel) {
+		redirect(`/${encodeURIComponent(channel)}/search?query=${encodeURIComponent(search)}`);
+	}
+}

--- a/storefront/src/app/[channel]/(main)/orders/page.tsx
+++ b/storefront/src/app/[channel]/(main)/orders/page.tsx
@@ -3,6 +3,8 @@ import { executeGraphQL } from "@/lib/graphql";
 import { LoginForm } from "@/ui/components/LoginForm";
 import { OrderListItem } from "@/ui/components/OrderListItem";
 
+export const dynamic = "force-dynamic";
+
 export default async function OrderPage() {
 	const { me: user } = await executeGraphQL(CurrentUserOrderListDocument, {
 		cache: "no-cache",

--- a/storefront/src/app/[channel]/(main)/page.tsx
+++ b/storefront/src/app/[channel]/(main)/page.tsx
@@ -1,9 +1,9 @@
-import { redirect } from "next/navigation";
 import Link from "next/link";
 import { SearchIcon, Package, Sparkles, Users, Calendar } from "lucide-react";
 import { ProductList } from "@/ui/components/ProductList";
 import { SetIconImage } from "@/ui/components/SetIconImage";
 import { getLatestSets, getTrendingProducts } from "@/lib/filters";
+import { handleSearchAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -89,14 +89,6 @@ export default async function Page(props: { params: Promise<{ channel: string }>
 		getTrendingProducts(params.channel, 8),
 		getLatestSets(params.channel, 6),
 	]);
-
-	async function handleSearch(formData: FormData) {
-		"use server";
-		const search = formData.get("search") as string;
-		if (search && search.trim().length > 0) {
-			redirect(`/${encodeURIComponent(params.channel)}/search?query=${encodeURIComponent(search)}`);
-		}
-	}
 
 	return (
 		<>
@@ -241,7 +233,8 @@ export default async function Page(props: { params: Promise<{ channel: string }>
 				<div className="mx-auto max-w-3xl px-8 text-center">
 					<h2 className="font-display text-xl font-bold text-neutral-900">Find Your Cards</h2>
 					<p className="mt-2 text-neutral-600">Search over 100,000 Magic: The Gathering cards</p>
-					<form action={handleSearch} className="mx-auto mt-6 max-w-xl">
+					<form action={handleSearchAction} className="mx-auto mt-6 max-w-xl">
+						<input type="hidden" name="channel" value={params.channel} />
 						<div className="relative">
 							<input
 								type="text"

--- a/storefront/src/app/[channel]/(main)/products/[slug]/page.tsx
+++ b/storefront/src/app/[channel]/(main)/products/[slug]/page.tsx
@@ -1,14 +1,14 @@
 import { cache, Suspense } from "react";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { type ResolvingMetadata, type Metadata } from "next";
 import { type WithContext, type Product } from "schema-dts";
 import { AddToCartForm } from "./AddToCartForm";
-import { VariantSelector } from "@/ui/components/VariantSelector";
+import { VariantSelector, pickDefaultVariant } from "@/ui/components/VariantSelector";
 import { ProductImageWrapper } from "@/ui/atoms/ProductImageWrapper";
 import { EssentialCardInfo } from "@/ui/components/EssentialCardInfo";
 import { MTGCardAttributes } from "@/ui/components/MTGCardAttributes";
 import { executeGraphQL } from "@/lib/graphql";
-import { formatMoney, formatMoneyRange } from "@/lib/utils";
+import { formatMoney, formatMoneyRange, getHrefForVariant } from "@/lib/utils";
 import { ProductDetailsDocument, ProductListDocument } from "@/gql/graphql";
 import { AvailabilityMessage } from "@/ui/components/AvailabilityMessage";
 import { LazyOtherPrintings } from "@/ui/components/LazyOtherPrintings";
@@ -108,6 +108,18 @@ export default async function Page(props: {
 	const selectedVariantID = searchParams.variant;
 	const selectedVariant = variants?.find(({ id }) => id === selectedVariantID);
 
+	// Auto-select best variant before any JSX renders — redirect at the page
+	// level fires at the top of the RSC response, avoiding blank pages during
+	// client-side navigation (redirect mid-render breaks RSC streaming).
+	if (!selectedVariant && variants && variants.length >= 1) {
+		const best = pickDefaultVariant(variants);
+		if (best) {
+			redirect(
+				`/${params.channel}${getHrefForVariant({ productSlug: product.slug, variantId: best.id })}`,
+			);
+		}
+	}
+
 	const isAvailable = variants?.some((variant) => variant.quantityAvailable) ?? false;
 
 	const price = selectedVariant?.pricing?.price?.gross
@@ -198,7 +210,6 @@ export default async function Page(props: {
 							selectedVariant={selectedVariant}
 							variants={variants}
 							product={product}
-							channel={params.channel}
 						/>
 					)}
 

--- a/storefront/src/ui/components/LoginForm.tsx
+++ b/storefront/src/ui/components/LoginForm.tsx
@@ -1,32 +1,13 @@
-import { redirect } from "next/navigation";
-import { getServerAuthClient } from "@/app/config";
+import { loginAction } from "./login-actions";
 
 export async function LoginForm({ redirectTo = "/" }: { redirectTo?: string }) {
 	return (
 		<div className="mx-auto mt-16 w-full max-w-lg">
 			<form
 				className="rounded border p-8 shadow-md"
-				action={async (formData) => {
-					"use server";
-
-					const email = formData.get("email")?.toString();
-					const password = formData.get("password")?.toString();
-
-					if (!email || !password) {
-						throw new Error("Email and password are required");
-					}
-
-					const { data } = await (
-						await getServerAuthClient()
-					).signIn({ email, password }, { cache: "no-store" });
-
-					if (data.tokenCreate.errors.length > 0) {
-						throw new Error(data.tokenCreate.errors.map((e) => e.message).join(", "));
-					}
-
-					redirect(redirectTo);
-				}}
+				action={loginAction}
 			>
+				<input type="hidden" name="redirectTo" value={redirectTo} />
 				<div className="mb-2">
 					<label className="sr-only" htmlFor="email">
 						Email

--- a/storefront/src/ui/components/VariantSelector.tsx
+++ b/storefront/src/ui/components/VariantSelector.tsx
@@ -1,5 +1,4 @@
 import { clsx } from "clsx";
-import { redirect } from "next/navigation";
 import { LinkWithChannel } from "../atoms/LinkWithChannel";
 import { type ProductListItemFragment, type VariantDetailsFragment } from "@/gql/graphql";
 import { getHrefForVariant } from "@/lib/utils";
@@ -111,6 +110,17 @@ function sortVariantsByCondition(variants: readonly VariantDetailsFragment[]): V
 }
 
 /**
+ * Pick the default variant to auto-select when none is specified.
+ * Prefers in-stock NM Non-Foil, falls back by condition/finish order.
+ * Exported so the page component can redirect before rendering.
+ */
+export function pickDefaultVariant(
+	variants: readonly VariantDetailsFragment[],
+): VariantDetailsFragment | undefined {
+	return findBestAvailableVariant(variants) ?? sortVariantsByCondition(variants)[0];
+}
+
+/**
  * Find the best available variant by condition order within a finish.
  */
 function findBestAvailableVariant(
@@ -152,26 +162,16 @@ export function VariantSelector({
 	variants,
 	product,
 	selectedVariant,
-	channel,
 }: {
 	variants: readonly VariantDetailsFragment[];
 	product: ProductListItemFragment;
 	selectedVariant?: VariantDetailsFragment;
-	channel: string;
 }) {
 	// Get available finishes for this product
 	const availableFinishes = getAvailableFinishes(variants);
 	// Determine current finish and condition from selected variant
 	const currentFinish = selectedVariant ? getFinishFromVariant(selectedVariant) : availableFinishes[0] || "Non-Foil";
 	const currentCondition = selectedVariant ? getConditionFromVariant(selectedVariant) : null;
-
-	// Auto-select best available variant if none selected (prefer NM, fall back to first by condition order)
-	if (!selectedVariant && variants.length >= 1) {
-		const bestVariant = findBestAvailableVariant(variants) ?? sortVariantsByCondition(variants)[0];
-		if (bestVariant) {
-			redirect("/" + channel + getHrefForVariant({ productSlug: product.slug, variantId: bestVariant.id }));
-		}
-	}
 
 	// Filter variants by selected finish for condition display
 	const variantsForFinish = variants.filter((v) => getFinishFromVariant(v) === currentFinish);

--- a/storefront/src/ui/components/login-actions.ts
+++ b/storefront/src/ui/components/login-actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { getServerAuthClient } from "@/app/config";
+
+export async function loginAction(formData: FormData) {
+	const email = formData.get("email")?.toString();
+	const password = formData.get("password")?.toString();
+	const redirectTo = formData.get("redirectTo")?.toString() || "/";
+
+	if (!email || !password) {
+		throw new Error("Email and password are required");
+	}
+
+	const { data } = await (
+		await getServerAuthClient()
+	).signIn({ email, password }, { cache: "no-store" });
+
+	if (data.tokenCreate.errors.length > 0) {
+		throw new Error(data.tokenCreate.errors.map((e) => e.message).join(", "));
+	}
+
+	redirect(redirectTo);
+}


### PR DESCRIPTION
## Summary
- Product pages appeared blank on client-side navigation (clicking a card from homepage/search) but loaded correctly on refresh
- Root cause: `redirect()` in `VariantSelector` (Server Component) fired mid-RSC-stream during client navigation, which Next.js 16 doesn't handle correctly
- Fix: moved the auto-variant-selection `redirect()` to the top of the page component, before any JSX renders, so it fires at the start of the RSC response

## Test plan
- [ ] Click a product card from the homepage → page loads with variant selected (not blank)
- [ ] Click a product card from search results → same behavior
- [ ] Refresh a product page → still works as before
- [ ] Variant selector (condition/finish buttons) still functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)