### PR TITLE
fix: singles-builder search not loading on client-side navigation

### DIFF
--- a/storefront/src/app/singles-builder/[channel]/page.tsx
+++ b/storefront/src/app/singles-builder/[channel]/page.tsx
@@ -135,7 +135,7 @@ export default async function SinglesBuilderPage({ params, searchParams }: PageP
 						</p>
 					</div>
 
-					<Suspense fallback={<SearchResultsSkeleton />}>
+					<Suspense key={`${searchQuery}-${urlSearchParams.toString()}`} fallback={<SearchResultsSkeleton />}>
 						<SearchResults channel={channel} searchQuery={searchQuery} filter={graphqlFilter} filterState={filterState} />
 					</Suspense>
 				</section>


### PR DESCRIPTION
## Summary

- **Singles-builder search broken on client-side nav** — typing a query showed the skeleton loader but never resolved to results. Full page refresh worked fine.
- Root cause: `<Suspense>` boundary had no `key` prop, so React reused the stale boundary during client-side navigation instead of remounting
- Fix: add `key` derived from `searchQuery + urlSearchParams` to force Suspense remount on each search
- Also includes reindex script improvements (submodule update): per-channel Saleor queries, warehouse-scoped stock, `MEILISEARCH_CHANNELS` env var support

## Test plan

- [ ] Navigate to `/singles-builder/singles-builder` as staff user
- [ ] Type "lightning bolt" in search — results should appear without page refresh
- [ ] Change search query — results should update dynamically
- [ ] Apply filters (rarity, condition) — results should re-render with skeleton
- [ ] Verify NM variants always shown, other conditions shown only when in stock

🤖 Generated with [Claude Code](https://claude.com/claude-code)