### PR TITLE
chore: remove old buylist and mtg-import apps after consolidation

### DIFF
--- a/.claude/hooks/pre-pr-lint.sh
+++ b/.claude/hooks/pre-pr-lint.sh
@@ -39,7 +39,6 @@ if [[ -d "$APPS_DIR" ]]; then
   APPS_LINT_EXIT=0
   LINT_OUTPUT=$(pnpm turbo run lint \
     --filter=saleor-app-inventory-ops \
-    --filter=saleor-app-buylist \
     --filter=saleor-app-pos 2>&1) || APPS_LINT_EXIT=$?
 
   if [[ $APPS_LINT_EXIT -ne 0 ]]; then

--- a/docs/ops/runbooks/github-actions-submodules.md
+++ b/docs/ops/runbooks/github-actions-submodules.md
@@ -12,9 +12,7 @@ When using `submodules: recursive`, GitHub Actions attempts to clone:
 2. `saleor-apps` submodule - works with default token
 3. Nested submodules in `saleor-apps/apps/` - **fails** because these are separate private repos:
    - `michael-a-bean/saleor-app-inventory-ops`
-   - `michael-a-bean/saleor-app-buylist`
    - `michael-a-bean/saleor-app-pos`
-   - `michael-a-bean/saleor-app-price-sync`
 
 ## Solution
 
@@ -34,9 +32,7 @@ A `SUBMODULES_TOKEN` secret provides cross-repo access.
      - `saleor-platform`
      - `saleor-apps`
      - `saleor-app-inventory-ops`
-     - `saleor-app-buylist`
      - `saleor-app-pos`
-     - `saleor-app-price-sync`
    - **Permissions:**
      - Repository permissions → **Contents: Read-only**
 4. Click **Generate token**

--- a/docs/reference/expected-divergence.md
+++ b/docs/reference/expected-divergence.md
@@ -17,8 +17,7 @@ All ECS services use `lifecycle { ignore_changes = [task_definition] }` to allow
 - `storefront` - Next.js storefront
 - `dashboard` - Saleor Dashboard
 - `stripe` - Stripe payment app
-- `inventory-ops` - Inventory operations app
-- `buylist` - Customer buylist app
+- `inventory-ops` - Inventory operations app (includes buylist + import functionality)
 - `pos` - Point of sale app
 - `meilisearch` - Search service
 
@@ -110,7 +109,7 @@ The Terraform-managed storefront task definition sets `SALEOR_API_URL` and `NEXT
 
 ## Prisma Shared Schema (Intentional — CI/CD Pattern)
 
-**inventory-ops**, **POS**, **buylist**, and **mtg-import** share a single Prisma schema via symlinks. All point to `inventory-ops/prisma/schema.prisma` and share the same `inventory_ops` database.
+**inventory-ops** and **POS** share a single Prisma schema via symlinks. Both point to `inventory-ops/prisma/schema.prisma` and share the same `inventory_ops` database. (buylist and mtg-import were consolidated into inventory-ops, Mar 2026.)
 
 **CI/CD Rule:** Only **inventory-ops** runs `prisma migrate deploy`. Other apps must NOT run migrations independently because:
 

--- a/docs/reference/mtg-import-app.md
+++ b/docs/reference/mtg-import-app.md
@@ -1,7 +1,11 @@
-# MTG Import App — Definitive Reference
+# MTG Import App — Definitive Reference (LEGACY)
 
-> Generated from exhaustive source code analysis, 2026-02-20.
-> Source: `saleor-apps/apps/mtg-import/`
+> **DEPRECATED**: The standalone mtg-import app was consolidated into `inventory-ops` (Mar 2026).
+> Import functionality now lives at `saleor-apps/apps/inventory-ops/src/modules/import/`.
+> This document is retained for historical context only.
+>
+> Originally generated from source code analysis, 2026-02-20.
+> Original source: `saleor-apps/apps/mtg-import/` (deleted)
 
 ## Overview
 

--- a/docs/reference/testing/testing-standards.md
+++ b/docs/reference/testing/testing-standards.md
@@ -210,7 +210,6 @@ export const createMockCostEvent = (overrides = {}) => ({
 pnpm test:ci
 
 # Run specific app tests
-pnpm --filter saleor-app-buylist test
 pnpm --filter saleor-app-inventory-ops test
 pnpm --filter saleor-app-pos test
 
@@ -218,7 +217,7 @@ pnpm --filter saleor-app-pos test
 pnpm test:ci -- --coverage
 
 # Watch mode for development
-pnpm --filter saleor-app-buylist test -- --watch
+pnpm --filter saleor-app-inventory-ops test -- --watch
 ```
 
 ---
@@ -245,8 +244,7 @@ When adding tests, prioritize:
 | App | Test Files | Notes |
 |-----|------------|-------|
 | pos | 1 | `register-router.test.ts` |
-| inventory-ops | 0 | No tests |
-| buylist | 0 | No tests |
+| inventory-ops | 12+ | WAC, price-sync, card-matcher, import pipeline |
 | storefront | 0 | No tests |
 
 This document captures patterns for future test writing, not a backlog to clear.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -486,7 +486,7 @@ module "ecs" {
     inventory-ops = {
       port             = 3002
       cpu              = 256
-      memory           = 1024 # Bumped: now handles inventory-ops + buylist + mtg-import workloads
+      memory           = 1024 # Bumped: consolidated app (inventory-ops absorbs buylist + import)
       base_path        = "/apps/inventory"
       image            = "${module.ecr.inventory_ops_app_repository_url}:${var.inventory_ops_app_image_tag}"
       target_group_arn = module.alb.inventory_ops_app_target_group_arn

--- a/infra/terraform/modules/cloudfront-storefront/main.tf
+++ b/infra/terraform/modules/cloudfront-storefront/main.tf
@@ -112,10 +112,10 @@ resource "aws_cloudfront_origin_request_policy" "alb_forwarding" {
         "Accept",
         "Accept-Language",
         "Referer",
-        "Next-Action",         # Server action ID — without this, Next.js returns HTML instead of action response
+        "Next-Action",            # Server action ID — without this, Next.js returns HTML instead of action response
         "Next-Router-State-Tree", # RSC navigation state
-        "RSC",                 # React Server Components request marker
-        "Content-Type",        # POST body content type
+        "RSC",                    # React Server Components request marker
+        "Content-Type",           # POST body content type
       ]
     }
   }

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -10,9 +10,7 @@ locals {
     "storefront",
     "stripe-app",
     "inventory-ops-app",
-    "buylist-app",
     "pos-app",
-    "mtg-import-app",
   ])
 }
 

--- a/scripts/pos-build/run-pos-build.sh
+++ b/scripts/pos-build/run-pos-build.sh
@@ -259,13 +259,13 @@ wait_and_commit_workers() {
       ((failed++))
     else
       # Commit changes through nested submodule chain:
-      # saleor-apps/apps/{pos,inventory-ops,buylist} → saleor-apps → main worktree
+      # saleor-apps/apps/{pos,inventory-ops} → saleor-apps → main worktree
       local worktree_path="${WORKTREE_BASE}/${name}"
       local sub="${worktree_path}/saleor-apps"
       local has_changes=false
 
       # Step 1: Commit inside each nested app submodule
-      for app in apps/pos apps/inventory-ops apps/buylist; do
+      for app in apps/pos apps/inventory-ops; do
         local appdir="${sub}/${app}"
         if [[ -d "${appdir}" ]] && [[ -n "$(git -C "${appdir}" status --porcelain 2>/dev/null)" ]]; then
           git -C "${appdir}" add -A
@@ -532,8 +532,8 @@ IMPLEMENT:
    - cashSummary hides expected cash when enabled
    - Variance still calculated and revealed after close
 
-NOTE: Buylist app is at saleor-apps/apps/buylist/src/modules/
-The pricing rule engine is in buylist/src/modules/pricing/rule-engine/rule-stacker.ts"
+NOTE: Buylist modules are now in saleor-apps/apps/inventory-ops/src/modules/buylist/
+The pricing rule engine is in inventory-ops/src/modules/buylist/pricing/rule-engine/rule-stacker.ts"
   launch_worker "product-catalog" "feature/pos-product-catalog" "${COMMON_PROMPT}
 
 YOUR DOMAIN: Product Catalog (3.3 — Service / Non-Inventory Item)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -109,7 +109,7 @@ fi
 
 # Step 10: Start app services
 log_info "Starting Saleor apps..."
-docker compose up -d stripe-app inventory-ops-app buylist-app pos-app
+docker compose up -d stripe-app inventory-ops-app pos-app
 
 # Final status
 echo ""


### PR DESCRIPTION
## Summary

- Remove old `apps/buylist/` (submodule) and `apps/mtg-import/` (directory) from saleor-apps after consolidation into inventory-ops
- Clean up all infrastructure, scripts, hooks, and documentation references
- Remove orphaned ECR repository definitions from Terraform (will destroy `saleor-platform/buylist-app` and `saleor-platform/mtg-import-app` repos on apply)

## Red Team Analysis

Before executing, 4 parallel agents verified safety:
- **Dependencies**: No cross-app imports from inventory-ops/POS to old apps (only comments)
- **Webhooks**: Neither old app declared webhooks, no delivery risk
- **CI/CD**: pnpm-lock.yaml regenerated clean; no workflow references to old apps
- **Terraform**: ECR removal is isolated — only 2 repos + 2 lifecycle policies destroyed, no cascade

## Changes

### Saleor-Apps Submodule
- Delete `apps/mtg-import/` (361MB, 70 files, 1561-line router)
- Deinit `apps/buylist/` submodule + remove from `.gitmodules`
- Regenerate `pnpm-lock.yaml`

### Platform
- `scripts/setup.sh` — remove `buylist-app` from docker compose up
- `.claude/hooks/pre-pr-lint.sh` — remove `--filter=saleor-app-buylist`
- `scripts/pos-build/run-pos-build.sh` — update paths from `apps/buylist` to `inventory-ops`
- `infra/terraform/modules/ecr/main.tf` — remove `buylist-app`, `mtg-import-app`
- `infra/terraform/main.tf` — update stale memory comment
- Docs: mark mtg-import-app.md as legacy, update testing-standards, expected-divergence, submodule runbook

## Post-Merge Actions

1. **Terraform apply** — plan will show 4 resources to destroy (2 ECR repos + 2 lifecycle policies)
2. **AWS task definitions** — deregister orphaned `saleor-platform-staging-buylist` and `saleor-platform-staging-mtg-import` families
3. **Saleor Dashboard** — verify old apps are not installed (uninstall if so)

## Test plan

- [x] pnpm install succeeds in saleor-apps after removal
- [x] terraform validate passes
- [x] No saleor-app-buylist in scripts or hooks
- [x] No saleor-app-mtg-import in any active config
- [x] No buylist-app or mtg-import-app in Terraform
- [x] CI/CD workflows have no references to old apps
- [ ] CI pipeline passes (test-platform)

Generated with [Claude Code](https://claude.com/claude-code)