### PR TITLE
feat: Meilisearch-backed category pages (#85)

### DIFF
--- a/storefront/src/app/[channel]/(main)/categories/[slug]/actions.ts
+++ b/storefront/src/app/[channel]/(main)/categories/[slug]/actions.ts
@@ -1,0 +1,93 @@
+"use server";
+
+import {
+	searchProducts,
+	isMeilisearchHealthy,
+	type MeilisearchProduct,
+} from "@/lib/meilisearch";
+
+export interface CategoryMetadata {
+	id: string;
+	name: string;
+	slug: string;
+	description: string | null;
+	seoTitle: string | null;
+	seoDescription: string | null;
+}
+
+const CATEGORY_METADATA_QUERY = `
+	query CategoryMetadata($slug: String!) {
+		category(slug: $slug) {
+			id
+			name
+			slug
+			description
+			seoTitle
+			seoDescription
+		}
+	}
+`;
+
+/**
+ * Fetch category metadata (name, SEO) without products.
+ * Uses a direct GraphQL call with 5-min cache to avoid the heavy product fetch.
+ */
+export async function fetchCategoryMetadata(slug: string): Promise<CategoryMetadata | null> {
+	const apiUrl = process.env.SALEOR_API_URL || process.env.NEXT_PUBLIC_SALEOR_API_URL;
+	if (!apiUrl) return null;
+
+	try {
+		const response = await fetch(apiUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				query: CATEGORY_METADATA_QUERY,
+				operationName: "CategoryMetadata",
+				variables: { slug },
+			}),
+			next: { revalidate: 300 },
+		});
+
+		if (!response.ok) return null;
+
+		const json = (await response.json()) as { data?: { category: CategoryMetadata | null } };
+		return json.data?.category ?? null;
+	} catch {
+		return null;
+	}
+}
+
+export interface CategorySearchResult {
+	products: MeilisearchProduct[];
+	totalCount: number;
+	processingTimeMs: number;
+}
+
+export async function searchCategoryProducts(
+	categorySlug: string,
+	channel: string,
+	options: {
+		limit?: number;
+		offset?: number;
+		sort?: string[];
+	} = {},
+): Promise<CategorySearchResult> {
+	const { limit = 24, offset = 0, sort } = options;
+
+	const result = await searchProducts("", channel, {
+		limit,
+		offset,
+		filters: { categorySlug },
+		sort,
+	});
+
+	return {
+		products: result.hits,
+		totalCount: result.estimatedTotalHits,
+		processingTimeMs: result.processingTimeMs,
+	};
+}
+
+export async function checkMeilisearchHealth(): Promise<boolean> {
+	return isMeilisearchHealthy();
+}

--- a/storefront/src/app/[channel]/(main)/categories/[slug]/page.tsx
+++ b/storefront/src/app/[channel]/(main)/categories/[slug]/page.tsx
@@ -7,29 +7,109 @@ import { executeGraphQL } from "@/lib/graphql";
 import { getPaginatedListVariables } from "@/lib/utils";
 import { ProductList } from "@/ui/components/ProductList";
 import { Pagination } from "@/ui/components/Pagination";
+import { fetchCategoryMetadata, searchCategoryProducts, checkMeilisearchHealth } from "./actions";
+import { transformMeilisearchResults, createMeilisearchPageInfo } from "../../search/transforms";
 
 export const generateMetadata = async (
 	props: { params: Promise<{ slug: string; channel: string }> },
 	parent: ResolvingMetadata,
 ): Promise<Metadata> => {
 	const params = await props.params;
-	const { category } = await executeGraphQL(ProductListByCategoryDocument, {
-		variables: { slug: params.slug, channel: params.channel },
-		revalidate: 60,
-	});
+	const metadata = await fetchCategoryMetadata(params.slug);
 
 	return {
-		title: `${category?.name || "Category"} | ${category?.seoTitle || (await parent).title?.absolute}`,
-		description: category?.seoDescription || category?.description || category?.seoTitle || category?.name,
+		title: `${metadata?.name || "Category"} | ${metadata?.seoTitle || (await parent).title?.absolute}`,
+		description: metadata?.seoDescription || metadata?.description || metadata?.seoTitle || metadata?.name,
 	};
+};
+
+/**
+ * Get Meilisearch sort from URL sort param.
+ */
+const getMeilisearchSort = (sortParam?: string): string[] => {
+	switch (sortParam) {
+		case "price-asc":
+			return ["min_price:asc"];
+		case "price-desc":
+			return ["min_price:desc"];
+		default:
+			return ["name:asc"];
+	}
+};
+
+/**
+ * Parse offset from cursor param. Gracefully handles old cursor-based pagination
+ * URLs by returning 0 (page 1) for unrecognized formats.
+ */
+const getMeilisearchOffset = (
+	cursor: string | undefined,
+	direction: string | undefined,
+	limit: number,
+): number => {
+	if (!cursor) return 0;
+	const match = cursor.match(/^offset:(\d+)$/);
+	if (!match) return 0;
+	const cursorOffset = parseInt(match[1], 10);
+	if (isNaN(cursorOffset)) return 0;
+	if (direction === "prev") {
+		return Math.max(0, cursorOffset - limit);
+	}
+	return cursorOffset;
 };
 
 export default async function Page(props: {
 	params: Promise<{ slug: string; channel: string }>;
-	searchParams: Promise<{ cursor?: string; direction?: string }>;
+	searchParams: Promise<{ cursor?: string; direction?: string; sort?: string }>;
 }) {
 	const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
 
+	// Always fetch category metadata from Saleor (cached 5 min).
+	// This determines if the category exists (notFound if not)
+	// and provides name + SEO regardless of which product source we use.
+	const metadata = await fetchCategoryMetadata(params.slug);
+	if (!metadata) {
+		notFound();
+	}
+
+	// Try Meilisearch first for products
+	const useMeilisearch = await checkMeilisearchHealth();
+
+	if (useMeilisearch) {
+		const limit = 24;
+		const offset = getMeilisearchOffset(searchParams.cursor, searchParams.direction, limit);
+		const sort = getMeilisearchSort(searchParams.sort);
+
+		const result = await searchCategoryProducts(params.slug, params.channel, {
+			limit,
+			offset,
+			sort,
+		});
+
+		// Amendment A3: If Meilisearch returns 0 results on first page,
+		// fall back to GraphQL to verify (Meili may be stale/reindexing).
+		if (result.totalCount === 0 && offset === 0) {
+			// Fall through to GraphQL path below
+		} else {
+			const productList = transformMeilisearchResults(result.products);
+			const pageInfo = createMeilisearchPageInfo(offset, limit, result.totalCount);
+
+			return (
+				<div className="mx-auto max-w-7xl p-8 pb-16">
+					<h1 className="pb-8 text-xl font-semibold">{metadata.name}</h1>
+					<p className="pb-4 text-sm text-neutral-500">
+						{result.totalCount} {result.totalCount === 1 ? "product" : "products"}
+						{result.processingTimeMs > 0 && (
+							<span className="ml-2 text-neutral-400">({result.processingTimeMs}ms)</span>
+						)}
+					</p>
+					<ProductList products={productList} />
+					<Pagination pageInfo={pageInfo} />
+				</div>
+			);
+		}
+	}
+
+	// GraphQL fallback path (original behavior)
 	const paginationVars = getPaginatedListVariables({ params: searchParams, pageSize: 24 });
 
 	const { category } = await executeGraphQL(ProductListByCategoryDocument, {
@@ -41,8 +121,7 @@ export default async function Page(props: {
 		notFound();
 	}
 
-	const { name, products } = category;
-	// Type assertion: codegen types are stale (missing pageInfo/totalCount that exist in .graphql source)
+	const { products } = category;
 	const productsWithPagination = products as typeof products & {
 		totalCount?: number;
 		pageInfo?: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null };
@@ -50,7 +129,7 @@ export default async function Page(props: {
 
 	return (
 		<div className="mx-auto max-w-7xl p-8 pb-16">
-			<h1 className="pb-8 text-xl font-semibold">{name}</h1>
+			<h1 className="pb-8 text-xl font-semibold">{metadata.name}</h1>
 			{productsWithPagination.totalCount != null && (
 				<p className="pb-4 text-sm text-neutral-500">{productsWithPagination.totalCount} products</p>
 			)}

--- a/storefront/src/lib/meilisearch.ts
+++ b/storefront/src/lib/meilisearch.ts
@@ -65,6 +65,9 @@ export interface MeilisearchProduct {
 	conditions_available: string[];
 	finishes_available: string[];
 	variants: MeilisearchVariant[];
+	category_id: string;
+	category_name: string;
+	category_slug: string;
 }
 
 export interface MeilisearchSearchResult {
@@ -84,7 +87,15 @@ export interface SearchFilters {
 	setName?: string;
 	rarity?: string | string[];
 	typeLine?: string;
+	categorySlug?: string;
 	priceRange?: { min?: number; max?: number };
+}
+
+/**
+ * Escape special characters in Meilisearch filter values.
+ */
+function escapeFilter(v: string): string {
+	return v.replace(/["\\]/g, "\\$&");
 }
 
 /**
@@ -98,36 +109,37 @@ function buildFilterString(filters: SearchFilters): string | undefined {
 	}
 
 	if (filters.conditions && filters.conditions.length > 0) {
-		// Match any of the conditions
-		const conditionFilters = filters.conditions.map((c) => `conditions_available = "${c}"`);
+		const conditionFilters = filters.conditions.map((c) => `conditions_available = "${escapeFilter(c)}"`);
 		parts.push(`(${conditionFilters.join(" OR ")})`);
 	}
 
 	if (filters.finishes && filters.finishes.length > 0) {
-		const finishFilters = filters.finishes.map((f) => `finishes_available = "${f}"`);
+		const finishFilters = filters.finishes.map((f) => `finishes_available = "${escapeFilter(f)}"`);
 		parts.push(`(${finishFilters.join(" OR ")})`);
 	}
 
 	if (filters.setCode) {
-		parts.push(`set_code = "${filters.setCode.toUpperCase()}"`);
+		parts.push(`set_code = "${escapeFilter(filters.setCode.toUpperCase())}"`);
 	}
 
 	if (filters.setName) {
-		parts.push(`set_name = "${filters.setName}"`);
+		parts.push(`set_name = "${escapeFilter(filters.setName)}"`);
 	}
 
 	if (filters.rarity) {
-		// Handle single string or array of rarities
 		const rarities = Array.isArray(filters.rarity) ? filters.rarity : [filters.rarity];
 		if (rarities.length > 0) {
-			const rarityFilters = rarities.map((r) => `rarity = "${r.toLowerCase()}"`);
+			const rarityFilters = rarities.map((r) => `rarity = "${escapeFilter(r.toLowerCase())}"`);
 			parts.push(`(${rarityFilters.join(" OR ")})`);
 		}
 	}
 
 	if (filters.typeLine) {
-		// Match partial type line (e.g., "Creature" matches "Legendary Creature — Dragon")
-		parts.push(`type_line = "${filters.typeLine}"`);
+		parts.push(`type_line = "${escapeFilter(filters.typeLine)}"`);
+	}
+
+	if (filters.categorySlug) {
+		parts.push(`category_slug = "${escapeFilter(filters.categorySlug)}"`);
 	}
 
 	if (filters.priceRange) {
@@ -184,6 +196,8 @@ export async function searchProducts(
 			"conditions_available",
 			"finishes_available",
 			"variants",
+			"category_slug",
+			"category_name",
 		],
 	};
 


### PR DESCRIPTION
## Summary

- Add `category_slug`, `category_name`, `category_id` to Meilisearch product documents for fast category page rendering (~50ms vs 3-5s cold start)
- Category page now tries Meilisearch first with automatic GraphQL fallback
- New `CATEGORY_UPDATED` and `CATEGORY_DELETED` webhook handlers keep category data in sync
- Filter value escaping added to all storefront Meilisearch filters (pre-existing bug fix)
- Sync buffer `maxBufferSize` prevents memory accumulation during bulk operations

## Changes

**Backend (inventory-ops):**
- `document-transformer.ts`: category fields in `SaleorProductPayload` + `MeilisearchDocument` + transform
- 4 GraphQL queries updated: product-created, product-updated, reindex, variant-sync
- `maintenance-router.ts`: `category_slug/name/id` in filterableAttributes, `category_name` in sortableAttributes
- `sync-buffer.ts`: `maxBufferSize` (500) triggers early flush
- New `category-updated/` webhook: partial-updates category fields directly in Meilisearch
- New `category-deleted/` webhook: clears category fields on orphaned docs

**Frontend (storefront):**
- `meilisearch.ts`: `escapeFilter()`, `categorySlug` filter, category fields in types + attributesToRetrieve
- `categories/[slug]/page.tsx`: Meilisearch-first + GraphQL fallback + zero-result verification + notFound()
- `categories/[slug]/actions.ts`: new server actions for category metadata + Meilisearch search

## Red Team Validation

24-agent adversarial analysis identified and addressed:
- **A1**: Filter injection — added `escapeFilter()` to all string interpolations
- **A2**: Buffer memory bomb — `maxBufferSize` prevents 10k+ doc accumulation
- **A3**: Stale health cache — zero-result fallback verifies with GraphQL
- **A7**: CATEGORY_DELETED lookup — `category_id` added to filterableAttributes
- **A8**: Missing 404 — metadata query always runs, guards nonexistent slugs

## Test plan

- [ ] TypeScript compiles cleanly (verified: 0 new errors)
- [ ] Existing search page still works (filter escaping is additive-only)
- [ ] Category page loads via GraphQL fallback (before reindex)
- [ ] After reindex: category page loads from Meilisearch (<100ms)
- [ ] Category rename in Dashboard propagates to Meilisearch
- [ ] Category delete clears fields on orphaned docs
- [ ] Nonexistent category slug returns 404
- [ ] Old cursor-format URLs gracefully start from page 1

## Deploy notes

**After merge, before enabling Meilisearch category pages:**
1. Deploy inventory-ops (new webhooks register automatically)
2. Trigger full reindex via Dashboard → Settings → Reindex Meilisearch (~30 min)
3. Verify: `category_slug` field present in Meilisearch documents
4. Deploy storefront (category pages now use Meilisearch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)