### PR TITLE
feat: printable pull list for singles-builder cart

### DIFF
--- a/storefront/src/app/globals.css
+++ b/storefront/src/app/globals.css
@@ -198,43 +198,164 @@ body {
 	font-display: swap;
 }
 
-/* Print styles for Singles Builder Pull List */
+/* Pull list: hide on screen, show on print */
+@media screen {
+	.pull-list-screen-hide {
+		display: none;
+	}
+}
+
+/* Print styles for Singles Builder Pull List — 8.5 x 11 US Letter */
 @media print {
-	/* Hide everything except the cart drawer */
+	@page {
+		size: letter portrait;
+		margin: 0.5in;
+	}
+
+	/* Hide everything except the pull list */
 	body > * {
 		display: none !important;
 	}
 
-	/* Show the cart drawer content */
-	body > div:last-child {
+	/* The pull list component renders inside a portal-like structure;
+	   target it by ID for reliability */
+	#pull-list-print,
+	#pull-list-print * {
+		visibility: visible !important;
+	}
+
+	body {
 		display: block !important;
 	}
 
-	/* Hide non-printable elements */
+	.pull-list-print {
+		display: block !important;
+		position: absolute !important;
+		top: 0;
+		left: 0;
+		width: 100% !important;
+		font-family: Arial, Helvetica, sans-serif;
+		font-size: 11px;
+		color: #000;
+		background: #fff;
+	}
+
+	/* Header */
+	.pull-list-header {
+		margin-bottom: 12px;
+		border-bottom: 2px solid #000;
+		padding-bottom: 8px;
+	}
+
+	.pull-list-title {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+	}
+
+	.pull-list-title h1 {
+		font-size: 20px;
+		font-weight: bold;
+		margin: 0;
+	}
+
+	.pull-list-location {
+		font-size: 14px;
+		font-weight: 600;
+		text-transform: uppercase;
+	}
+
+	.pull-list-meta {
+		margin-top: 4px;
+	}
+
+	.pull-list-meta-row {
+		display: flex;
+		gap: 24px;
+		font-size: 11px;
+		line-height: 1.6;
+	}
+
+	.pull-list-code {
+		font-weight: bold;
+		font-family: monospace;
+		font-size: 13px;
+		letter-spacing: 0.1em;
+	}
+
+	/* Table */
+	.pull-list-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 11px;
+	}
+
+	.pull-list-table thead {
+		border-bottom: 2px solid #000;
+	}
+
+	.pull-list-table th {
+		text-align: left;
+		font-weight: bold;
+		padding: 3px 6px;
+		font-size: 10px;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+	}
+
+	.pull-list-table td {
+		padding: 4px 6px;
+		border-bottom: 1px solid #ddd;
+		vertical-align: top;
+	}
+
+	.pull-list-table tbody tr:nth-child(even) {
+		background: #f8f8f8;
+	}
+
+	/* Column widths */
+	.pull-list-col-check { width: 20px; text-align: center; }
+	.pull-list-col-qty   { width: 30px; text-align: center; }
+	.pull-list-col-cond  { width: 40px; }
+	.pull-list-col-finish { width: 55px; }
+	.pull-list-col-set   { width: 40px; font-family: monospace; text-transform: uppercase; }
+	.pull-list-col-num   { width: 35px; text-align: right; font-family: monospace; }
+	.pull-list-col-name  { /* flex */ }
+	.pull-list-col-price { width: 55px; text-align: right; font-family: monospace; }
+
+	/* Checkbox */
+	.pull-list-checkbox {
+		display: inline-block;
+		width: 12px;
+		height: 12px;
+		border: 1.5px solid #000;
+		vertical-align: middle;
+	}
+
+	/* Footer */
+	.pull-list-footer {
+		display: flex;
+		justify-content: space-between;
+		margin-top: 8px;
+		padding-top: 6px;
+		border-top: 2px solid #000;
+		font-size: 12px;
+	}
+
+	.pull-list-total {
+		font-weight: bold;
+		font-size: 13px;
+	}
+
+	/* Hide screen-only elements */
 	.print\:hidden,
 	button,
 	input,
 	textarea,
-	[aria-hidden="true"] {
+	[aria-hidden="true"],
+	nav,
+	header,
+	footer {
 		display: none !important;
-	}
-
-	/* Clean layout for pull list */
-	.fixed {
-		position: static !important;
-		width: 100% !important;
-		max-width: 100% !important;
-		box-shadow: none !important;
-	}
-
-	/* Add pull list header via CSS */
-	.fixed::before {
-		content: "Pull List — " attr(data-location) " — " attr(data-date);
-		display: block;
-		font-size: 18px;
-		font-weight: bold;
-		margin-bottom: 16px;
-		border-bottom: 2px solid #000;
-		padding-bottom: 8px;
 	}
 }

--- a/storefront/src/app/singles-builder/[channel]/components/CartDrawer.tsx
+++ b/storefront/src/app/singles-builder/[channel]/components/CartDrawer.tsx
@@ -12,6 +12,7 @@ import {
 	type CartActionResult,
 } from "../actions";
 import { useStaff } from "../../StaffContext";
+import { PullListPrint } from "./PullListPrint";
 
 // Convert full condition name to abbreviation
 function abbreviateCondition(condition: string): string {
@@ -413,6 +414,21 @@ export function CartDrawer({ channel }: CartDrawerProps) {
 					</div>
 				)}
 			</div>
+
+			{/* Pull list — hidden on screen, shown only by @media print CSS */}
+			{cart && cart.lines.length > 0 && (
+				<div className="pull-list-screen-hide">
+					<PullListPrint
+						lines={cart.lines}
+						channel={channel}
+						customerName={customerInfo.name}
+						notes={customerInfo.notes}
+						shortCode={shortCode}
+						totalAmount={cart.totalPrice?.gross?.amount ?? 0}
+						totalCurrency={cart.totalPrice?.gross?.currency ?? "USD"}
+					/>
+				</div>
+			)}
 		</>
 	);
 }

--- a/storefront/src/app/singles-builder/[channel]/components/PullListPrint.tsx
+++ b/storefront/src/app/singles-builder/[channel]/components/PullListPrint.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { type CartLine } from "../store/singlesCartStore";
+
+function getAttribute(
+	attributes: Array<{ attribute: { slug: string }; values: Array<{ name: string }> }>,
+	slug: string,
+): string {
+	return attributes.find((a) => a.attribute.slug === slug)?.values[0]?.name ?? "";
+}
+
+const CONDITION_ABBREV: Record<string, string> = {
+	"Near Mint": "NM",
+	"Lightly Played": "LP",
+	"Moderately Played": "MP",
+	"Heavily Played": "HP",
+	Damaged: "DMG",
+};
+
+interface PullListRow {
+	quantity: number;
+	condition: string;
+	finish: string;
+	setCode: string;
+	collectorNumber: string;
+	cardName: string;
+	price: string;
+}
+
+function buildRows(lines: CartLine[]): PullListRow[] {
+	return lines
+		.map((line) => {
+			const conditionFull = getAttribute(line.variant.attributes, "mtg-condition");
+			const condition = CONDITION_ABBREV[conditionFull] || conditionFull || "—";
+			const finish = getAttribute(line.variant.attributes, "mtg-finish") || "—";
+			const setCode = getAttribute(line.variant.product.attributes, "mtg-set-code");
+			const collectorNumber = getAttribute(line.variant.product.attributes, "mtg-collector-number");
+
+			return {
+				quantity: line.quantity,
+				condition,
+				finish,
+				setCode: setCode.toUpperCase(),
+				collectorNumber,
+				cardName: line.variant.product.name,
+				price: line.totalPrice?.gross?.amount != null
+					? `$${line.totalPrice.gross.amount.toFixed(2)}`
+					: "—",
+			};
+		})
+		.sort((a, b) => {
+			// Sort by set code, then collector number (numeric), then card name
+			const setCompare = a.setCode.localeCompare(b.setCode);
+			if (setCompare !== 0) return setCompare;
+			const numA = parseInt(a.collectorNumber, 10) || 0;
+			const numB = parseInt(b.collectorNumber, 10) || 0;
+			if (numA !== numB) return numA - numB;
+			return a.cardName.localeCompare(b.cardName);
+		});
+}
+
+interface PullListPrintProps {
+	lines: CartLine[];
+	channel: string;
+	customerName: string;
+	notes: string;
+	shortCode: string | null;
+	totalAmount: number;
+	totalCurrency: string;
+}
+
+export function PullListPrint({
+	lines,
+	channel,
+	customerName,
+	notes,
+	shortCode,
+	totalAmount,
+	totalCurrency,
+}: PullListPrintProps) {
+	const rows = buildRows(lines);
+	const totalQty = rows.reduce((sum, r) => sum + r.quantity, 0);
+	const now = new Date();
+	const dateStr = now.toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	});
+	const timeStr = now.toLocaleTimeString("en-US", {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+
+	return (
+		<div id="pull-list-print" className="pull-list-print">
+			{/* Header */}
+			<div className="pull-list-header">
+				<div className="pull-list-title">
+					<h1>Pull List</h1>
+					<span className="pull-list-location">{channel}</span>
+				</div>
+				<div className="pull-list-meta">
+					<div className="pull-list-meta-row">
+						<span>Date: {dateStr} {timeStr}</span>
+						{shortCode && <span className="pull-list-code">Code: {shortCode}</span>}
+					</div>
+					{customerName && (
+						<div className="pull-list-meta-row">
+							<span>Customer: {customerName}</span>
+						</div>
+					)}
+					{notes && (
+						<div className="pull-list-meta-row">
+							<span>Notes: {notes}</span>
+						</div>
+					)}
+				</div>
+			</div>
+
+			{/* Table */}
+			<table className="pull-list-table">
+				<thead>
+					<tr>
+						<th className="pull-list-col-check">&nbsp;</th>
+						<th className="pull-list-col-qty">Qty</th>
+						<th className="pull-list-col-cond">Cond</th>
+						<th className="pull-list-col-finish">Finish</th>
+						<th className="pull-list-col-set">Set</th>
+						<th className="pull-list-col-num">#</th>
+						<th className="pull-list-col-name">Card Name</th>
+						<th className="pull-list-col-price">Price</th>
+					</tr>
+				</thead>
+				<tbody>
+					{rows.map((row, i) => (
+						<tr key={i}>
+							<td className="pull-list-col-check">
+								<span className="pull-list-checkbox" />
+							</td>
+							<td className="pull-list-col-qty">{row.quantity}</td>
+							<td className="pull-list-col-cond">{row.condition}</td>
+							<td className="pull-list-col-finish">{row.finish}</td>
+							<td className="pull-list-col-set">{row.setCode}</td>
+							<td className="pull-list-col-num">{row.collectorNumber}</td>
+							<td className="pull-list-col-name">{row.cardName}</td>
+							<td className="pull-list-col-price">{row.price}</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+
+			{/* Footer */}
+			<div className="pull-list-footer">
+				<span>{totalQty} items / {rows.length} unique cards</span>
+				<span className="pull-list-total">
+					Total: ${totalAmount.toFixed(2)} {totalCurrency}
+				</span>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a formatted printable pull list when staff clicks "Print" in the singles-builder cart drawer
- 8.5x11 US Letter layout with 0.5in margins
- Table columns (per Michael's spec): Qty, Condition, Finish, Set Code, Collector #, Card Name, Price
- Rows sorted by set code + collector number (matches physical storage order)
- Checkboxes for marking items as pulled
- Header: location, date/time, customer name, POS code
- Footer: item count, unique cards, total price
- Replaces the old fragile print CSS that used `body > div:last-child` and empty `attr()` values

## Test plan
- [ ] Open singles-builder, add items to cart
- [ ] Click Print button in cart drawer
- [ ] Verify print preview shows formatted table on US Letter
- [ ] Verify columns are in order: checkbox, qty, condition, finish, set, #, name, price
- [ ] Verify rows sorted by set code then collector number
- [ ] Verify header shows location, date, customer name (if entered), POS code (if generated)
- [ ] Verify pull list is not visible on screen (only in print)

🤖 Generated with [Claude Code](https://claude.com/claude-code)