### PR TITLE
fix: pull list print shows blank page

### DIFF
--- a/storefront/src/app/globals.css
+++ b/storefront/src/app/globals.css
@@ -212,24 +212,18 @@ body {
 		margin: 0.5in;
 	}
 
-	/* Hide everything except the pull list */
-	body > * {
-		display: none !important;
+	/* Hide everything — use visibility (not display:none) so children can override */
+	body * {
+		visibility: hidden !important;
 	}
 
-	/* The pull list component renders inside a portal-like structure;
-	   target it by ID for reliability */
+	/* Show only the pull list and its descendants */
 	#pull-list-print,
 	#pull-list-print * {
 		visibility: visible !important;
 	}
 
-	body {
-		display: block !important;
-	}
-
 	.pull-list-print {
-		display: block !important;
 		position: absolute !important;
 		top: 0;
 		left: 0;


### PR DESCRIPTION
## Summary
- Pull list print was rendering a blank page (only browser headers visible)
- Root cause: `body > * { display: none !important }` in print CSS hid the Next.js root element, and `display: none` on a parent cannot be overridden by children
- Fix: switched to `visibility: hidden` which children CAN override with `visibility: visible`

## Test plan
- [ ] Open singles builder, add items to cart
- [ ] Click Print button in cart drawer
- [ ] Verify pull list renders with all cart content (card names, quantities, prices, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)