### PR TITLE
chore: bump Saleor API 3.22.42 + Dashboard 3.22.35

### DIFF
--- a/infra/terraform/environments/staging.tfvars
+++ b/infra/terraform/environments/staging.tfvars
@@ -117,9 +117,9 @@ apps_scaling_min_capacity = 1 # Always-on apps stay running; batch jobs (desired
 apps_scaling_max_capacity = 1 # 1 instance per app in staging
 
 # Images (pin by digest in production, use tags in staging)
-# Updated 2026-03-03: API 3.22.39, Dashboard 3.22.34
-saleor_api_image       = "ghcr.io/saleor/saleor:3.22.39"
-saleor_dashboard_image = "ghcr.io/saleor/saleor-dashboard:3.22.34"
+# Updated 2026-03-16: API 3.22.42 (PyJWT CVE fix), Dashboard 3.22.35 (dep security fixes)
+saleor_api_image       = "ghcr.io/saleor/saleor:3.22.42"
+saleor_dashboard_image = "ghcr.io/saleor/saleor-dashboard:3.22.35"
 
 # Saleor Apps image tags
 stripe_app_image_tag = "document-polyfill-v1"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -404,7 +404,7 @@ variable "saleor_api_image" {
 }
 
 variable "saleor_dashboard_image" {
-  description = "Saleor Dashboard image (3.22.24 is latest patch for 3.22 series)"
+  description = "Saleor Dashboard image (3.22.35 is latest patch for 3.22 series)"
   type        = string
   default     = "ghcr.io/saleor/saleor-dashboard:3.22.24"
 }


### PR DESCRIPTION
## Summary
- Bump staging API from 3.22.39 → 3.22.42 (PyJWT CVE-2026-32597 fix + 2 bug fixes)
- Bump staging Dashboard from 3.22.34 → 3.22.35 (dependency security fixes + schema updates)
- Update variables.tf description to reflect latest patch

## Deploy path
Merge → `terraform-apply.yml` auto-triggers on `infra/terraform/**` change → Terraform updates ECS task definitions → ECS rolls out new containers.

## Test plan
- [ ] `terraform-plan-on-pr` shows only task definition image changes
- [ ] Post-merge: API and Dashboard containers running new versions
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)