### PR TITLE
fix: POS payments, manual card, singles builder UX

### DIFF
--- a/storefront/src/app/singles-builder/[channel]/components/CartDrawer.tsx
+++ b/storefront/src/app/singles-builder/[channel]/components/CartDrawer.tsx
@@ -222,9 +222,14 @@ export function CartDrawer({ channel }: CartDrawerProps) {
 			const result = await saveCartForPOS(customerInfo.name, customerInfo.notes, code, staff.email, channel);
 			if (result.success) {
 				setShortCode(code);
-				handleCartUpdate(result);
 				setShowSuccess(true);
-				setTimeout(() => setShowSuccess(false), 5000);
+				// Clear local cart state — the Saleor checkout stays intact for POS to import from
+				clearCart();
+				setShortCode(code); // Re-set after clearCart so the success banner can show it
+				setTimeout(() => {
+					setShowSuccess(false);
+					setShortCode(null);
+				}, 8000);
 			} else {
 				setError(result.error || "Failed to save cart");
 			}

--- a/storefront/src/app/singles-builder/layout.tsx
+++ b/storefront/src/app/singles-builder/layout.tsx
@@ -63,7 +63,7 @@ export default async function SinglesBuilderLayout({
 				</header>
 				<main>{children}</main>
 				<ToastContainer
-					position="bottom-right"
+					position="top-right"
 					autoClose={3000}
 					hideProgressBar={false}
 					newestOnTop


### PR DESCRIPTION
## Summary
- **POS: Fix payment error** — Remove `::uuid` casts in raw queries that caused `text = uuid` operator mismatch, breaking all card/cash payments
- **POS: Manual card payment** — Split "Pay with Card" into Terminal (Square integration) and Manual Card Entry (for non-integrated terminals). Staff can optionally enter last 4 digits + auth code
- **POS: Fix partial payment cap** — Cash payments were capped at full transaction total instead of remaining balance, allowing overpayment on split transactions
- **POS: Payment labels** — Display "Card (Terminal)", "Card (Manual ****1234)" instead of raw enum values
- **Storefront: Toast position** — Move singles builder notifications to top-right to avoid overlapping the cart button
- **Storefront: Clear cart after POS send** — Cart clears locally after successful handoff; success banner with code stays visible for 8 seconds

## Test plan
- [ ] POS: Record a cash payment on a transaction (previously crashed with uuid error)
- [ ] POS: Use Manual Card to pay — verify optional last 4 + auth code saved
- [ ] POS: Split payment: $50 cash then Manual Card for remainder
- [ ] POS: Payment summary shows correct labels for each type
- [ ] Storefront: Add item to singles builder cart — toast appears top-right
- [ ] Storefront: Send cart to POS — cart clears, success banner shows for 8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)