### PR TITLE
fix: Prisma Json typed fields + singles builder search index

### DIFF
--- a/storefront/src/app/singles-builder/[channel]/actions.ts
+++ b/storefront/src/app/singles-builder/[channel]/actions.ts
@@ -146,6 +146,7 @@ export async function searchWithMeilisearch(
 		limit,
 		offset,
 		filters,
+		indexPrefix: "singles-builder",
 	});
 
 	return {


### PR DESCRIPTION
## Summary
- **inventory-ops**: Add `prisma-json-types-generator` to replace Prisma's recursive `JsonValue` with concrete types at generate time. Annotates all 34 Json fields in the schema. Eliminates TS2589 without needing `typescript.ignoreBuildErrors`. Closes #130
- **storefront**: Fix singles builder search querying wrong Meilisearch index — was building index name from Saleor channel slug (`frank-and-sons-products`) instead of using the actual Meilisearch index (`singles-builder-products`). Added `indexPrefix: "singles-builder"` to route correctly.

## Test plan
- [x] `tsc --noEmit` shows 0 TS2589 errors (was 1 before)
- [x] `prisma generate` succeeds with json types generator
- [x] No new production code errors introduced (24 pre-existing lint errors unchanged)
- [x] Meilisearch `singles-builder-products` index has 101k docs, returns hits for "sun"
- [x] `frank-and-sons-products` confirmed as 404 (index doesn't exist)
- [ ] Singles builder search returns products after deploy
- [ ] Storefront builds without `ignoreBuildErrors`

Generated with [Claude Code](https://claude.com/claude-code)