### PR TITLE
feat: Frank & Sons search index + dynamic singles-builder routing

### DIFF
--- a/storefront/src/app/singles-builder/[channel]/actions.ts
+++ b/storefront/src/app/singles-builder/[channel]/actions.ts
@@ -146,7 +146,7 @@ export async function searchWithMeilisearch(
 		limit,
 		offset,
 		filters,
-		indexPrefix: "singles-builder",
+		indexPrefix: channel,
 	});
 
 	return {


### PR DESCRIPTION
## Summary

- **Saleor config** (already applied): Added Warehouse: Brea to Default shipping zone — stock now contributes to webstore + singles-builder channels
- **Meilisearch**: Added `frank-and-sons` channel to default config with warehouse-scoped stock (Franks warehouse only). Index created with full settings on staging.
- **Storefront**: Singles-builder search now routes to the correct Meilisearch index per location (`singles-builder-products` for Brea, `frank-and-sons-products` for Frank & Sons)

## Post-deploy

Trigger Meilisearch reindex from inventory-ops maintenance page to populate `frank-and-sons-products` index with product data.

## Test plan

- [ ] Singles-builder location picker shows both "Shuffle and Cut Games, Brea" and "Frank & Sons"
- [ ] Brea location searches `singles-builder-products` index (existing behavior preserved)
- [ ] Frank & Sons location searches `frank-and-sons-products` index (new)
- [ ] Webstore search unaffected (uses separate code path)
- [ ] After reindex: Frank & Sons search returns products with Franks warehouse stock only

🤖 Generated with [Claude Code](https://claude.com/claude-code)