### PR TITLE
fix: singles-builder search empty on first load

### DIFF
--- a/storefront/src/app/singles-builder/[channel]/page.tsx
+++ b/storefront/src/app/singles-builder/[channel]/page.tsx
@@ -115,16 +115,20 @@ export default async function SinglesBuilderPage({ params, searchParams }: PageP
 
 	return (
 		<div className="mx-auto max-w-7xl px-4 py-6">
-			{/* Search Header */}
+			{/* Search Header — Suspense required for useSearchParams */}
 			<div className="mb-6">
-				<SinglesSearch />
+				<Suspense fallback={<div className="h-12 animate-pulse rounded-lg bg-gray-100" />}>
+					<SinglesSearch />
+				</Suspense>
 			</div>
 
 			{/* Main Content Area */}
 			<div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
-				{/* Filter Sidebar */}
+				{/* Filter Sidebar — Suspense required for useSearchParams */}
 				<aside className="rounded-lg border bg-white p-4 shadow-sm lg:col-span-1">
-					<SinglesFilters />
+					<Suspense fallback={<div className="h-64 animate-pulse rounded bg-gray-100" />}>
+						<SinglesFilters />
+					</Suspense>
 				</aside>
 
 				{/* Results Area */}


### PR DESCRIPTION
## Summary
- Wrap `SinglesSearch` and `SinglesFilters` in `Suspense` boundaries
- Both components use `useSearchParams()` which requires Suspense in Next.js App Router
- Without Suspense, the page defers to client-side rendering, causing the first search to show empty results until a full page refresh

## Context
Same root cause as the webstore search fix in PR #102. The `useSearchParams()` hook without a Suspense boundary causes React to bail out of server-side rendering for the entire page.

## Test plan
- [ ] Navigate to `/singles-builder/frank-and-sons`
- [ ] Type a search query and press Enter
- [ ] Verify results appear on first search without needing a refresh
- [ ] Verify same behavior on `/singles-builder/singles-builder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)