### PR TITLE
fix: POS product name display + nested submodule CI detection

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -117,9 +117,11 @@ jobs:
           echo "$CHANGED_FILES"
 
           # Check each app directory for changes
+          # Match both "apps/pos/src/file.ts" (file changes) and
+          # "apps/pos" (nested submodule pointer change — no trailing slash)
           check_app() {
             local app_dir="$1"
-            if echo "$CHANGED_FILES" | grep -q "^${app_dir}/"; then
+            if echo "$CHANGED_FILES" | grep -q "^${app_dir}\(/\|$\)"; then
               echo "true"
             else
               echo "false"

--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -89,9 +89,11 @@ jobs:
           echo "Changed files in submodule:"
           echo "$CHANGED_FILES"
 
+          # Match both file paths (apps/pos/src/...) and nested submodule
+          # pointer changes (apps/pos without trailing slash)
           check_app() {
             local app_dir="$1"
-            if echo "$CHANGED_FILES" | grep -q "^${app_dir}/"; then
+            if echo "$CHANGED_FILES" | grep -q "^${app_dir}\(/\|$\)"; then
               echo "true"
             else
               echo "false"


### PR DESCRIPTION
## Summary

- Display product name (card name) on POS transaction line items
- Fix CI/CD nested submodule detection that caused POS builds to be silently skipped

## Product Name Display

| Before | After |
|--------|-------|
| Near Mint - Non-Foil | **Black Lotus** |
| (variant name only) | Near Mint - Non-Foil |

- New `saleorProductName` column on `PosTransactionLine` (Prisma migration)
- Stored on both SKU/barcode scan and singles builder import
- Existing lines without product name gracefully fall back to variant name

## CI/CD Fix

`check_app()` in both `deploy-staging.yml` and `test-platform.yml` matched file paths (`apps/pos/src/...`) but not nested submodule pointer changes (`apps/pos` without trailing slash). Changed grep from `"^apps/pos/"` to `"^apps/pos(/|$)"`.

This was the root cause of PR #155's deploy skipping the POS build — and the original cause of the POS reversion.

## Test plan

- [ ] POS line items show product name bold with variant below
- [ ] CI detects POS changes when only nested submodule pointer updates
- [ ] Prisma migration runs on deploy (adds nullable column)

Generated with Claude Code