### PR TITLE
fix: unshallow nested submodules + fallback pointer detection in CI

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -64,9 +64,13 @@ jobs:
 
       # Shallow clone (fetch-depth: 2) doesn't give the submodule enough
       # history for `git diff --submodule=diff` to compute file-level diffs.
-      # Unshallow just the submodule so the diff step can see actual changes.
+      # Must unshallow saleor-apps AND its nested submodules (pos, inventory-ops)
+      # so git can enumerate actual file changes, not just pointer diffs.
       - name: Ensure submodule history for diff
-        run: git -C saleor-apps fetch --unshallow 2>/dev/null || true
+        run: |
+          git -C saleor-apps fetch --unshallow 2>/dev/null || true
+          git -C saleor-apps/apps/pos fetch --unshallow 2>/dev/null || true
+          git -C saleor-apps/apps/inventory-ops fetch --unshallow 2>/dev/null || true
 
       - name: Detect changed paths (non-submodule)
         uses: dorny/paths-filter@v3
@@ -113,15 +117,21 @@ jobs:
           # The saleor-apps/ prefix (submodule mount point) must be stripped so
           # check_app can match against bare paths like "apps/inventory-ops/".
           CHANGED_FILES=$(echo "$DIFF" | grep '^diff --git' | sed 's|diff --git a/||; s| b/.*||; s|^saleor-apps/||')
-          echo "Changed files in submodule:"
-          echo "$CHANGED_FILES"
+
+          # Fallback: if shallow clone couldn't produce file-level diffs,
+          # detect nested submodule pointer changes from "Submodule apps/pos OLD..NEW" lines
+          POINTER_CHANGES=$(echo "$DIFF" | grep '^Submodule apps/' | sed 's|^Submodule ||; s| .*||')
+
+          ALL_CHANGES=$(printf "%s\n%s" "$CHANGED_FILES" "$POINTER_CHANGES" | sort -u | grep -v '^$')
+          echo "Changed files/pointers in submodule:"
+          echo "$ALL_CHANGES"
 
           # Check each app directory for changes
           # Match both "apps/pos/src/file.ts" (file changes) and
           # "apps/pos" (nested submodule pointer change — no trailing slash)
           check_app() {
             local app_dir="$1"
-            if echo "$CHANGED_FILES" | grep -q "^${app_dir}\(/\|$\)"; then
+            if echo "$ALL_CHANGES" | grep -q "^${app_dir}\(/\|$\)"; then
               echo "true"
             else
               echo "false"

--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -35,9 +35,13 @@ jobs:
 
       # Shallow clone (fetch-depth: 2) doesn't give the submodule enough
       # history for `git diff --submodule=diff` to compute file-level diffs.
-      # Unshallow just the submodule so the diff step can see actual changes.
+      # Must unshallow saleor-apps AND its nested submodules (pos, inventory-ops)
+      # so git can enumerate actual file changes, not just pointer diffs.
       - name: Ensure submodule history for diff
-        run: git -C saleor-apps fetch --unshallow 2>/dev/null || true
+        run: |
+          git -C saleor-apps fetch --unshallow 2>/dev/null || true
+          git -C saleor-apps/apps/pos fetch --unshallow 2>/dev/null || true
+          git -C saleor-apps/apps/inventory-ops fetch --unshallow 2>/dev/null || true
 
       - name: Detect changed paths
         uses: dorny/paths-filter@v3
@@ -86,14 +90,20 @@ jobs:
 
           echo "Submodule diff detected, checking which apps changed..."
           CHANGED_FILES=$(echo "$DIFF" | grep '^diff --git' | sed 's|diff --git a/||; s| b/.*||; s|^saleor-apps/||')
-          echo "Changed files in submodule:"
-          echo "$CHANGED_FILES"
+
+          # Fallback: if shallow clone couldn't produce file-level diffs,
+          # detect nested submodule pointer changes from "Submodule apps/pos OLD..NEW" lines
+          POINTER_CHANGES=$(echo "$DIFF" | grep '^Submodule apps/' | sed 's|^Submodule ||; s| .*||')
+
+          ALL_CHANGES=$(printf "%s\n%s" "$CHANGED_FILES" "$POINTER_CHANGES" | sort -u | grep -v '^$')
+          echo "Changed files/pointers in submodule:"
+          echo "$ALL_CHANGES"
 
           # Match both file paths (apps/pos/src/...) and nested submodule
           # pointer changes (apps/pos without trailing slash)
           check_app() {
             local app_dir="$1"
-            if echo "$CHANGED_FILES" | grep -q "^${app_dir}\(/\|$\)"; then
+            if echo "$ALL_CHANGES" | grep -q "^${app_dir}\(/\|$\)"; then
               echo "true"
             else
               echo "false"


### PR DESCRIPTION
## Summary

Fixes the second (deeper) bug in nested submodule change detection that caused 7 deploy runs to silently skip POS/inventory-ops builds between Mar 16-18.

## Root Cause

PR #156 fixed Bug 1 (trailing-slash grep pattern). This fixes Bug 2:

1. `fetch --unshallow` only ran on `saleor-apps`, not on `apps/pos` or `apps/inventory-ops` inside it. With shallow clones, `git diff --submodule=diff` couldn't enumerate file changes for nested submodules — `CHANGED_FILES` was completely empty.

2. Even with unshallowing, there's an edge case where file-level diffs aren't produced. Added fallback: parse `Submodule apps/pos OLD..NEW` header lines to detect pointer changes.

## Changes

- `fetch --unshallow` now runs on all 3 levels: saleor-apps, apps/pos, apps/inventory-ops
- New `POINTER_CHANGES` variable captures submodule header lines as fallback
- `ALL_CHANGES` combines both sources for `check_app()` to match against
- Applied to both `deploy-staging.yml` and `test-platform.yml`

## Test plan

- [ ] Deploy run detects POS changes when only nested submodule pointer updates
- [ ] Deploy run detects inventory-ops changes when only nested submodule pointer updates
- [ ] No false positives — unchanged apps still skip correctly

Generated with Claude Code