### PR TITLE
fix: singles builder cart cleanup after send-to-POS

### DIFF
--- a/storefront/src/app/singles-builder/[channel]/components/CartDrawer.tsx
+++ b/storefront/src/app/singles-builder/[channel]/components/CartDrawer.tsx
@@ -223,8 +223,10 @@ export function CartDrawer({ channel }: CartDrawerProps) {
 			if (result.success) {
 				setShortCode(code);
 				setShowSuccess(true);
-				// Clear local cart state — the Saleor checkout stays intact for POS to import from
+				// Clear local cart state AND delete the checkout cookie so
+				// refreshing doesn't reload the same items from Saleor
 				clearCart();
+				await clearSinglesCart(channel);
 				setShortCode(code); // Re-set after clearCart so the success banner can show it
 				setTimeout(() => {
 					setShowSuccess(false);


### PR DESCRIPTION
## Summary

Fixes ghost carts reappearing after sending singles builder cart to POS and completing the transaction.

## Root Cause

Two bugs working together:

1. **Storefront** (`CartDrawer.tsx`): `handleGenerateCode` called `clearCart()` (Zustand only) but not `clearSinglesCart(channel)` (cookie deletion). On page refresh, the cookie caused the checkout to reload from Saleor with the same items.

2. **POS** (`transactions-router.ts`): `importFromSinglesBuilder` only deleted 3 of 6 metadata keys and left checkout lines intact in Saleor. Even after metadata deletion, the checkout still had items that could be reloaded.

## Fixes

- **Storefront**: Add `await clearSinglesCart(channel)` after successful send — deletes the checkout cookie
- **POS**: Delete all 6 metadata keys + remove all checkout lines via `checkoutLinesDelete` mutation after import

Also fixes "0 in cart" count mismatch — caused by cleared Zustand state vs stale cookie reloading items.

## Test plan

- [ ] Send singles builder cart to POS
- [ ] Import on POS, complete transaction
- [ ] Refresh singles builder page — cart should be empty
- [ ] POS should not show the cart again
- [ ] Cart count should match actual items

Generated with Claude Code