### PR TITLE
fix: enable S3 for webhook payload storage (#183)

### DIFF
--- a/infra/terraform/modules/ecs/main.tf
+++ b/infra/terraform/modules/ecs/main.tf
@@ -113,8 +113,10 @@ resource "aws_ecs_task_definition" "api" {
           { name = "ALLOWED_CLIENT_HOSTS", value = var.allowed_hosts },
           { name = "DEFAULT_CHANNEL_SLUG", value = "webstore" },
           # S3 Media Storage - AWS_MEDIA_BUCKET_NAME is required for product images
+          # AWS_MEDIA_PRIVATE_BUCKET_NAME enables S3 for webhook payloads (EventPayload.payload_file)
           { name = "AWS_STORAGE_BUCKET_NAME", value = var.media_bucket_name },
           { name = "AWS_MEDIA_BUCKET_NAME", value = var.media_bucket_name },
+          { name = "AWS_MEDIA_PRIVATE_BUCKET_NAME", value = var.media_bucket_name },
           { name = "AWS_S3_REGION_NAME", value = var.aws_region },
           { name = "DASHBOARD_URL", value = "${var.public_dashboard_base_url}/" },
           { name = "ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL", value = "false" },
@@ -214,8 +216,10 @@ resource "aws_ecs_task_definition" "worker" {
           { name = "ALLOWED_CLIENT_HOSTS", value = var.allowed_hosts },
           { name = "DEFAULT_CHANNEL_SLUG", value = "webstore" },
           # S3 Media Storage - AWS_MEDIA_BUCKET_NAME is required for product images
+          # AWS_MEDIA_PRIVATE_BUCKET_NAME enables S3 for webhook payloads (EventPayload.payload_file)
           { name = "AWS_STORAGE_BUCKET_NAME", value = var.media_bucket_name },
           { name = "AWS_MEDIA_BUCKET_NAME", value = var.media_bucket_name },
+          { name = "AWS_MEDIA_PRIVATE_BUCKET_NAME", value = var.media_bucket_name },
           { name = "AWS_S3_REGION_NAME", value = var.aws_region },
           { name = "PUBLIC_URL", value = "${var.public_api_base_url}/" }
         ],
@@ -684,6 +688,7 @@ resource "aws_ecs_task_definition" "migrate" {
         # S3 Media Storage
         { name = "AWS_STORAGE_BUCKET_NAME", value = var.media_bucket_name },
         { name = "AWS_MEDIA_BUCKET_NAME", value = var.media_bucket_name },
+        { name = "AWS_MEDIA_PRIVATE_BUCKET_NAME", value = var.media_bucket_name },
         { name = "AWS_S3_REGION_NAME", value = var.aws_region }
       ]
       logConfiguration = {


### PR DESCRIPTION
## Summary

- Adds `AWS_MEDIA_PRIVATE_BUCKET_NAME` env var to API, worker, and migrate ECS task definitions
- Saleor 3.22's `EventPayload.payload_file` uses `PRIVATE_FILE_STORAGE`, which defaults to local `FileSystemStorage` — since API and worker are separate ECS tasks, the worker gets `FileNotFoundError` on every webhook delivery
- Setting this env var switches to `S3MediaPrivateStorage`, using the existing S3 media bucket (IAM permissions already in place)

## Root cause detail

```
EventPayload.payload_file → storage=private_storage
  → saleor.core.PrivateStorage → settings.PRIVATE_FILE_STORAGE
    → without AWS_MEDIA_PRIVATE_BUCKET_NAME: django.core.files.storage.FileSystemStorage (local disk)
    → with AWS_MEDIA_PRIVATE_BUCKET_NAME: saleor.core.storages.S3MediaPrivateStorage (S3)
```

`AWS_MEDIA_BUCKET_NAME` (public media) was already set. `AWS_MEDIA_PRIVATE_BUCKET_NAME` (webhook payloads) was not.

## Post-merge steps

1. `terraform apply` to update task definitions
2. Redeploy API + worker ECS services
3. Purge 426k stale pending deliveries from `core_eventdelivery` (payload files are lost on local ephemeral storage)
4. Verify fresh webhook delivery works (e.g., update a product, check worker logs)
5. Verify ORDER_FULFILLED → inventory-ops SaleEvent pipeline

Closes #183

## Test plan

- [ ] `terraform plan` shows only env var additions to api/worker/migrate task defs
- [ ] After deploy, update a product in Dashboard → verify `product_updated` webhook delivers successfully
- [ ] Trigger ORDER_FULFILLED → verify inventory-ops receives the webhook and creates SaleEvent

🤖 Generated with [Claude Code](https://claude.com/claude-code)