### PR TITLE
feat: configure SES SMTP for transactional emails (#43)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -198,6 +198,12 @@
 - **Fix**: Activate channel in Dashboard. See `mtg-import-singles-builder-investigation.md` for full details.
 - **Still open**: Duplicate products from slug case mismatch (old mixed-case vs new lowercase).
 
+### Webhook Payload Storage (CRITICAL — discovered 2026-03-20)
+- See `memory/project_webhook_payload_storage.md` for full details
+- ALL webhook delivery broken: API writes payloads to `/app/media/payloads/`, worker can't read them (separate ECS tasks)
+- 426k+ pending deliveries, zero successful. Blocks COGS, Meilisearch sync, stock detection.
+- Fix: S3 media storage or shared EFS volume between API and worker
+
 ### MVP Progress (verified 2026-02-28)
 - **Overall**: ~94% complete. Full details: `memory/mvp-staging-verification.md`
 - **Remaining**: (1) Email SMTP GUI setup, (2) Buylist manual FOH→BOH test, (3) Place test order

--- a/.claude/memory/project_webhook_payload_storage.md
+++ b/.claude/memory/project_webhook_payload_storage.md
@@ -1,0 +1,19 @@
+---
+name: webhook-payload-storage-fixed
+description: Saleor webhook payloads now use S3 via AWS_MEDIA_PRIVATE_BUCKET_NAME — fixed 2026-03-23
+type: project
+---
+
+Saleor webhook delivery was broken on staging since inception — fixed 2026-03-23 (PR #184, issue #183).
+
+**Root cause**: Saleor 3.22 has TWO storage backends:
+- `AWS_MEDIA_BUCKET_NAME` → `STORAGES["default"]` (product images, public media) — was set
+- `AWS_MEDIA_PRIVATE_BUCKET_NAME` → `PRIVATE_FILE_STORAGE` (webhook payloads via `EventPayload.payload_file`) — was NOT set
+
+Without the private bucket, payloads wrote to local `FileSystemStorage` — broken across separate ECS containers.
+
+**Fix**: Added `AWS_MEDIA_PRIVATE_BUCKET_NAME` env var to API, worker, and migrate task definitions in Terraform. Uses same S3 bucket as media (IAM already covered).
+
+**Why:** This is a critical distinction in Saleor's storage model. `DEFAULT_FILE_STORAGE` (media) and `PRIVATE_FILE_STORAGE` (webhook payloads) are separate settings with separate env vars.
+
+**How to apply:** If adding new Saleor containers that process webhooks, they need BOTH `AWS_MEDIA_BUCKET_NAME` and `AWS_MEDIA_PRIVATE_BUCKET_NAME`. Also relevant if migrating to a new environment.

--- a/docs/ops/incident-changes.md
+++ b/docs/ops/incident-changes.md
@@ -265,3 +265,11 @@ After any manual infrastructure change:
    - [ ] Check GitHub Actions drift detection results
    - [ ] Review any open drift issues
    - [ ] Close reconciled items
+
+## 2026-03-22: SES SMTP Egress Rule
+
+- **Resource**: Security Group Rule `sgr-0d13b144518789398` on `sg-0210b4854c817f8ac`
+- **Action**: Added TCP port 587 egress to 0.0.0.0/0 for SES SMTP
+- **Reason**: ECS tasks in private subnets could not reach SES SMTP endpoint (email-smtp.us-west-1.amazonaws.com:587)
+- **Terraform status**: SG not managed by Terraform — rule added via AWS CLI
+- **Tag**: ManagedBy: manual-2026-03-22

--- a/infra/terraform/modules/ecs/main.tf
+++ b/infra/terraform/modules/ecs/main.tf
@@ -96,6 +96,10 @@ resource "aws_ecs_task_definition" "api" {
           {
             name      = "RSA_PRIVATE_KEY"
             valueFrom = "${var.ssm_path_prefix}/api/RSA_PRIVATE_KEY"
+          },
+          {
+            name      = "EMAIL_URL"
+            valueFrom = "${var.ssm_path_prefix}/api/EMAIL_URL"
           }
         ],
         # OpenTelemetry auth header (Grafana Cloud Basic auth)
@@ -112,6 +116,7 @@ resource "aws_ecs_task_definition" "api" {
           { name = "ALLOWED_HOSTS", value = var.allowed_hosts },
           { name = "ALLOWED_CLIENT_HOSTS", value = var.allowed_hosts },
           { name = "DEFAULT_CHANNEL_SLUG", value = "webstore" },
+          { name = "DEFAULT_FROM_EMAIL", value = "Hobby Gaming Store <noreply@michaelbean.org>" },
           # S3 Media Storage - AWS_MEDIA_BUCKET_NAME is required for product images
           { name = "AWS_STORAGE_BUCKET_NAME", value = var.media_bucket_name },
           { name = "AWS_MEDIA_BUCKET_NAME", value = var.media_bucket_name },
@@ -197,6 +202,10 @@ resource "aws_ecs_task_definition" "worker" {
           {
             name      = "RSA_PRIVATE_KEY"
             valueFrom = "${var.ssm_path_prefix}/api/RSA_PRIVATE_KEY"
+          },
+          {
+            name      = "EMAIL_URL"
+            valueFrom = "${var.ssm_path_prefix}/api/EMAIL_URL"
           }
         ],
         # OpenTelemetry auth header (Grafana Cloud Basic auth)
@@ -213,6 +222,7 @@ resource "aws_ecs_task_definition" "worker" {
           { name = "ALLOWED_HOSTS", value = var.allowed_hosts },
           { name = "ALLOWED_CLIENT_HOSTS", value = var.allowed_hosts },
           { name = "DEFAULT_CHANNEL_SLUG", value = "webstore" },
+          { name = "DEFAULT_FROM_EMAIL", value = "Hobby Gaming Store <noreply@michaelbean.org>" },
           # S3 Media Storage - AWS_MEDIA_BUCKET_NAME is required for product images
           { name = "AWS_STORAGE_BUCKET_NAME", value = var.media_bucket_name },
           { name = "AWS_MEDIA_BUCKET_NAME", value = var.media_bucket_name },


### PR DESCRIPTION
## Summary
- Configure AWS SES SMTP for transactional email delivery (order confirmations, password resets, etc.)
- Add `EMAIL_URL` (SSM secret) and `DEFAULT_FROM_EMAIL` env vars to api + worker ECS task definitions
- SES domain identity `michaelbean.org` verified with DKIM in us-west-1
- Security group egress rule for port 587 (SMTP/TLS) documented in incident-changes.md
- User emails plugin activated on webstore channel via `pluginUpdate` GraphQL mutation

Closes #43

## Test plan
- [x] SES domain verification confirmed (DKIM SUCCESS)
- [x] SMTP credentials stored in SSM
- [x] ECS services deployed with new task definitions (api rev 271, worker rev 273)
- [x] User emails plugin activated — `pluginUpdate` returned zero errors
- [x] Test order placed — confirmation email received

🤖 Generated with [Claude Code](https://claude.com/claude-code)