### PR TITLE
feat: unified account system — registration, password reset, P1 fixes (#57)

### DIFF
--- a/storefront/src/app/[channel]/(main)/account/actions.ts
+++ b/storefront/src/app/[channel]/(main)/account/actions.ts
@@ -8,6 +8,7 @@ import {
 	AccountAddressDeleteDocument,
 	AccountAddressCreateDocument,
 	AccountAddressUpdateDocument,
+	RequestEmailChangeDocument,
 	CountryCode,
 	type AddressTypeEnum,
 } from "@/gql/graphql";
@@ -160,6 +161,33 @@ export async function updateAddress(channelSlug: string, addressId: string, form
 	}
 
 	redirect(`/${channelSlug}/account/addresses?status=address_updated`);
+}
+
+export async function requestEmailChange(channelSlug: string, formData: FormData) {
+	const newEmail = formData.get("newEmail")?.toString() ?? "";
+	const password = formData.get("password")?.toString() ?? "";
+
+	let result;
+	try {
+		result = await executeGraphQL(RequestEmailChangeDocument, {
+			variables: {
+				channel: channelSlug,
+				newEmail,
+				password,
+				redirectUrl: `${process.env.NEXT_PUBLIC_STOREFRONT_URL || ""}/${channelSlug}/account/confirm-email`,
+			},
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account?status=email_change_error`);
+	}
+
+	const errors = result.requestEmailChange?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account?status=email_change_error`);
+	}
+
+	redirect(`/${channelSlug}/account?status=email_change_requested`);
 }
 
 function extractAddressFromForm(formData: FormData) {

--- a/storefront/src/app/[channel]/(main)/account/confirm-email/actions.ts
+++ b/storefront/src/app/[channel]/(main)/account/confirm-email/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { executeGraphQL } from "@/lib/graphql";
+import { ConfirmEmailChangeDocument } from "@/gql/graphql";
+import { redirect } from "next/navigation";
+
+export async function confirmEmailChangeAction(channelSlug: string, formData: FormData) {
+	const token = formData.get("token")?.toString() ?? "";
+
+	let result;
+	try {
+		result = await executeGraphQL(ConfirmEmailChangeDocument, {
+			variables: {
+				channel: channelSlug,
+				token,
+			},
+			cache: "no-cache",
+		});
+	} catch {
+		redirect(`/${channelSlug}/account?status=email_confirm_error`);
+	}
+
+	const errors = result.confirmEmailChange?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/account?status=email_confirm_error`);
+	}
+
+	redirect(`/${channelSlug}/account?status=email_changed`);
+}

--- a/storefront/src/app/[channel]/(main)/account/confirm-email/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/confirm-email/page.tsx
@@ -1,0 +1,80 @@
+import { StatusBanner, type StatusMessage } from "@/ui/components/StatusBanner";
+import { confirmEmailChangeAction } from "./actions";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+const confirmMessages: Record<string, StatusMessage> = {
+	confirm_error: { type: "error", text: "Email confirmation failed. The link may have expired." },
+};
+
+export default async function ConfirmEmailPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ channel: string }>;
+	searchParams: Promise<{ token?: string; status?: string }>;
+}) {
+	const { channel } = await params;
+	const { token, status } = await searchParams;
+
+	const message = status ? (confirmMessages[status] ?? null) : null;
+
+	if (!token) {
+		return (
+			<div className="mx-auto max-w-7xl p-8">
+				<h1 className="text-center text-2xl font-bold tracking-tight text-neutral-900">
+					Confirm Email Change
+				</h1>
+				<StatusBanner
+					message={{ type: "error", text: "Invalid or missing confirmation token." }}
+				/>
+				<p className="mt-4 text-center text-sm text-neutral-600">
+					<Link
+						href={`/${channel}/account`}
+						className="text-blue-600 hover:text-blue-800"
+					>
+						Back to account
+					</Link>
+				</p>
+			</div>
+		);
+	}
+
+	const confirmWithChannel = confirmEmailChangeAction.bind(null, channel);
+
+	return (
+		<div className="mx-auto max-w-7xl p-8">
+			<h1 className="text-center text-2xl font-bold tracking-tight text-neutral-900">
+				Confirm Email Change
+			</h1>
+
+			<StatusBanner message={message} />
+
+			<div className="mx-auto mt-8 w-full max-w-lg">
+				<div className="rounded border bg-white p-8 shadow-md">
+					<p className="mb-6 text-sm text-neutral-600">
+						Click the button below to confirm your email address change.
+					</p>
+					<form action={confirmWithChannel}>
+						<input type="hidden" name="token" value={token} />
+						<button
+							type="submit"
+							className="w-full rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+						>
+							Confirm Email Change
+						</button>
+					</form>
+					<p className="mt-4 text-center text-sm text-neutral-600">
+						<Link
+							href={`/${channel}/account`}
+							className="text-blue-600 hover:text-blue-800"
+						>
+							Back to account
+						</Link>
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/account/messages.ts
+++ b/storefront/src/app/[channel]/(main)/account/messages.ts
@@ -8,6 +8,10 @@ const accountMessages: Record<string, StatusMessage> = {
 	password_required: { type: "error", text: "Current password is required." },
 	passwords_mismatch: { type: "error", text: "Passwords do not match." },
 	password_too_short: { type: "error", text: "Password must be at least 8 characters." },
+	email_change_requested: { type: "success", text: "Check your new email for a confirmation link." },
+	email_change_error: { type: "error", text: "Failed to request email change. Check your password and try again." },
+	email_changed: { type: "success", text: "Email address updated successfully." },
+	email_confirm_error: { type: "error", text: "Email confirmation failed. The link may have expired." },
 };
 
 const addressMessages: Record<string, StatusMessage> = {

--- a/storefront/src/app/[channel]/(main)/account/page.tsx
+++ b/storefront/src/app/[channel]/(main)/account/page.tsx
@@ -3,7 +3,7 @@ import { LoginForm } from "@/ui/components/LoginForm";
 import { StatusBanner } from "@/ui/components/StatusBanner";
 import { StoreCreditBadge } from "@/ui/components/StoreCreditBadge";
 import { LinkWithChannel } from "@/ui/atoms/LinkWithChannel";
-import { updateProfile, changePassword } from "./actions";
+import { updateProfile, changePassword, requestEmailChange } from "./actions";
 import { getAccountMessage } from "./messages";
 import { inputClassName, labelClassName } from "./styles";
 
@@ -28,6 +28,7 @@ export default async function AccountPage({
 	const message = getAccountMessage(status);
 	const updateProfileWithChannel = updateProfile.bind(null, channel);
 	const changePasswordWithChannel = changePassword.bind(null, channel);
+	const requestEmailChangeWithChannel = requestEmailChange.bind(null, channel);
 
 	return (
 		<div className="mx-auto max-w-7xl p-8">
@@ -82,6 +83,45 @@ export default async function AccountPage({
 							Save Changes
 						</button>
 					</form>
+					<div className="border-t px-6 py-4">
+						<details>
+							<summary className="cursor-pointer text-sm text-blue-600 hover:text-blue-800">
+								Change email
+							</summary>
+							<form action={requestEmailChangeWithChannel} className="mt-3 space-y-3">
+								<div>
+									<label htmlFor="newEmail" className={labelClassName}>
+										New Email
+									</label>
+									<input
+										id="newEmail"
+										name="newEmail"
+										type="email"
+										required
+										className={inputClassName}
+									/>
+								</div>
+								<div>
+									<label htmlFor="emailPassword" className={labelClassName}>
+										Current Password
+									</label>
+									<input
+										id="emailPassword"
+										name="password"
+										type="password"
+										required
+										className={inputClassName}
+									/>
+								</div>
+								<button
+									type="submit"
+									className="rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+								>
+									Request Change
+								</button>
+							</form>
+						</details>
+					</div>
 				</div>
 
 				{/* Password Section */}

--- a/storefront/src/app/[channel]/(main)/forgot-password/actions.ts
+++ b/storefront/src/app/[channel]/(main)/forgot-password/actions.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { executeGraphQL } from "@/lib/graphql";
+import { RequestPasswordResetDocument } from "@/gql/graphql";
+import { redirect } from "next/navigation";
+
+export async function requestPasswordResetAction(channelSlug: string, formData: FormData) {
+	const email = formData.get("email")?.toString() ?? "";
+
+	try {
+		await executeGraphQL(RequestPasswordResetDocument, {
+			variables: {
+				email,
+				redirectUrl: `${process.env.NEXT_PUBLIC_STOREFRONT_URL || ""}/${channelSlug}/reset-password`,
+				channel: channelSlug,
+			},
+			cache: "no-cache",
+			withAuth: false,
+		});
+	} catch {
+		// Silently succeed to prevent email enumeration
+	}
+
+	// Always show success regardless of whether email exists
+	redirect(`/${channelSlug}/forgot-password?status=email_sent`);
+}

--- a/storefront/src/app/[channel]/(main)/forgot-password/page.tsx
+++ b/storefront/src/app/[channel]/(main)/forgot-password/page.tsx
@@ -36,7 +36,7 @@ export default async function ForgotPasswordPage({
 			<div className="mx-auto mt-8 w-full max-w-lg">
 				<form action={requestResetWithChannel} className="rounded border bg-white p-8 shadow-md">
 					<p className="mb-4 text-sm text-neutral-600">
-						Enter your email address and we'll send you a link to reset your password.
+						Enter your email address and we&apos;ll send you a link to reset your password.
 					</p>
 					<div>
 						<label htmlFor="email" className={labelClassName}>

--- a/storefront/src/app/[channel]/(main)/forgot-password/page.tsx
+++ b/storefront/src/app/[channel]/(main)/forgot-password/page.tsx
@@ -1,0 +1,74 @@
+import { StatusBanner, type StatusMessage } from "@/ui/components/StatusBanner";
+import { inputClassName, labelClassName } from "../account/styles";
+import { requestPasswordResetAction } from "./actions";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+const forgotPasswordMessages: Record<string, StatusMessage> = {
+	email_sent: {
+		type: "success",
+		text: "If an account with that email exists, we've sent a password reset link.",
+	},
+};
+
+export default async function ForgotPasswordPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ channel: string }>;
+	searchParams: Promise<{ status?: string }>;
+}) {
+	const { channel } = await params;
+	const { status } = await searchParams;
+
+	const message = status ? (forgotPasswordMessages[status] ?? null) : null;
+	const requestResetWithChannel = requestPasswordResetAction.bind(null, channel);
+
+	return (
+		<div className="mx-auto max-w-7xl p-8">
+			<h1 className="text-center text-2xl font-bold tracking-tight text-neutral-900">
+				Forgot Password
+			</h1>
+
+			<StatusBanner message={message} />
+
+			<div className="mx-auto mt-8 w-full max-w-lg">
+				<form action={requestResetWithChannel} className="rounded border bg-white p-8 shadow-md">
+					<p className="mb-4 text-sm text-neutral-600">
+						Enter your email address and we'll send you a link to reset your password.
+					</p>
+					<div>
+						<label htmlFor="email" className={labelClassName}>
+							Email
+						</label>
+						<input
+							id="email"
+							name="email"
+							type="email"
+							required
+							autoComplete="email"
+							className={inputClassName}
+						/>
+					</div>
+
+					<button
+						type="submit"
+						className="mt-6 w-full rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+					>
+						Send Reset Link
+					</button>
+
+					<p className="mt-4 text-center text-sm text-neutral-600">
+						<Link
+							href={`/${channel}/login`}
+							className="text-blue-600 hover:text-blue-800"
+						>
+							Back to login
+						</Link>
+					</p>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/login/page.tsx
+++ b/storefront/src/app/[channel]/(main)/login/page.tsx
@@ -1,24 +1,40 @@
+import { getCurrentUser } from "@/lib/currentUser";
+import { LoginForm } from "@/ui/components/LoginForm";
+import { StatusBanner, type StatusMessage } from "@/ui/components/StatusBanner";
+import { redirect } from "next/navigation";
+
 export const dynamic = "force-dynamic";
 
-import { Suspense } from "react";
-import { Loader } from "@/ui/atoms/Loader";
-import { LoginForm } from "@/ui/components/LoginForm";
+const loginMessages: Record<string, StatusMessage> = {
+	registration_success: { type: "success", text: "Account created successfully! Please log in." },
+	password_reset: { type: "success", text: "Password reset successfully. Please log in." },
+	login_required: { type: "error", text: "Please log in to continue." },
+};
 
-interface PageProps {
+export default async function LoginPage({
+	params,
+	searchParams,
+}: {
 	params: Promise<{ channel: string }>;
-	searchParams: Promise<{ redirect?: string }>;
-}
-
-export default async function LoginPage({ params, searchParams }: PageProps) {
+	searchParams: Promise<{ status?: string; redirectTo?: string }>;
+}) {
 	const { channel } = await params;
-	const { redirect } = await searchParams;
-	const redirectTo = redirect || `/${channel}`;
+	const { status, redirectTo } = await searchParams;
+
+	const user = await getCurrentUser();
+	if (user) {
+		redirect(`/${channel}/account`);
+	}
+
+	const message = status ? (loginMessages[status] ?? null) : null;
 
 	return (
-		<Suspense fallback={<Loader />}>
-			<section className="mx-auto max-w-7xl p-8">
-				<LoginForm redirectTo={redirectTo} />
-			</section>
-		</Suspense>
+		<div className="mx-auto max-w-7xl p-8">
+			<h1 className="text-center text-2xl font-bold tracking-tight text-neutral-900">Log In</h1>
+
+			<StatusBanner message={message} />
+
+			<LoginForm redirectTo={redirectTo || `/${channel}/account`} channel={channel} />
+		</div>
 	);
 }

--- a/storefront/src/app/[channel]/(main)/register/actions.ts
+++ b/storefront/src/app/[channel]/(main)/register/actions.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { executeGraphQL } from "@/lib/graphql";
+import { AccountRegisterDocument } from "@/gql/graphql";
+import { redirect } from "next/navigation";
+
+export async function registerAction(channelSlug: string, formData: FormData) {
+	const email = formData.get("email")?.toString() ?? "";
+	const password = formData.get("password")?.toString() ?? "";
+	const confirmPassword = formData.get("confirmPassword")?.toString() ?? "";
+	const firstName = formData.get("firstName")?.toString() ?? "";
+	const lastName = formData.get("lastName")?.toString() ?? "";
+
+	if (password !== confirmPassword) {
+		redirect(`/${channelSlug}/register?status=passwords_mismatch`);
+	}
+
+	if (password.length < 8) {
+		redirect(`/${channelSlug}/register?status=password_too_short`);
+	}
+
+	let result;
+	try {
+		result = await executeGraphQL(AccountRegisterDocument, {
+			variables: {
+				input: {
+					email,
+					password,
+					firstName,
+					lastName,
+					channel: channelSlug,
+					redirectUrl: `${process.env.NEXT_PUBLIC_STOREFRONT_URL || ""}/${channelSlug}/account`,
+				},
+			},
+			cache: "no-cache",
+			withAuth: false,
+		});
+	} catch {
+		redirect(`/${channelSlug}/register?status=registration_error`);
+	}
+
+	const errors = result.accountRegister?.errors ?? [];
+	if (errors.length > 0) {
+		const code = errors.some((e) => e.code === "UNIQUE") ? "email_taken" : "registration_error";
+		redirect(`/${channelSlug}/register?status=${code}`);
+	}
+
+	redirect(`/${channelSlug}/login?status=registration_success`);
+}

--- a/storefront/src/app/[channel]/(main)/register/page.tsx
+++ b/storefront/src/app/[channel]/(main)/register/page.tsx
@@ -1,0 +1,135 @@
+import { getCurrentUser } from "@/lib/currentUser";
+import { StatusBanner, type StatusMessage } from "@/ui/components/StatusBanner";
+import { inputClassName, labelClassName } from "../account/styles";
+import { registerAction } from "./actions";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+const registerMessages: Record<string, StatusMessage> = {
+	email_taken: { type: "error", text: "An account with that email already exists." },
+	registration_error: { type: "error", text: "Registration failed. Please try again." },
+	passwords_mismatch: { type: "error", text: "Passwords do not match." },
+	password_too_short: { type: "error", text: "Password must be at least 8 characters." },
+};
+
+export default async function RegisterPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ channel: string }>;
+	searchParams: Promise<{ status?: string }>;
+}) {
+	const { channel } = await params;
+	const { status } = await searchParams;
+
+	const user = await getCurrentUser();
+	if (user) {
+		redirect(`/${channel}/account`);
+	}
+
+	const message = status ? (registerMessages[status] ?? null) : null;
+	const registerWithChannel = registerAction.bind(null, channel);
+
+	return (
+		<div className="mx-auto max-w-7xl p-8">
+			<h1 className="text-center text-2xl font-bold tracking-tight text-neutral-900">
+				Create Account
+			</h1>
+
+			<StatusBanner message={message} />
+
+			<div className="mx-auto mt-8 w-full max-w-lg">
+				<form action={registerWithChannel} className="rounded border bg-white p-8 shadow-md">
+					<div className="space-y-4">
+						<div className="grid gap-4 sm:grid-cols-2">
+							<div>
+								<label htmlFor="firstName" className={labelClassName}>
+									First Name
+								</label>
+								<input
+									id="firstName"
+									name="firstName"
+									type="text"
+									autoComplete="given-name"
+									className={inputClassName}
+								/>
+							</div>
+							<div>
+								<label htmlFor="lastName" className={labelClassName}>
+									Last Name
+								</label>
+								<input
+									id="lastName"
+									name="lastName"
+									type="text"
+									autoComplete="family-name"
+									className={inputClassName}
+								/>
+							</div>
+						</div>
+						<div>
+							<label htmlFor="email" className={labelClassName}>
+								Email
+							</label>
+							<input
+								id="email"
+								name="email"
+								type="email"
+								required
+								autoComplete="email"
+								className={inputClassName}
+							/>
+						</div>
+						<div>
+							<label htmlFor="password" className={labelClassName}>
+								Password
+							</label>
+							<input
+								id="password"
+								name="password"
+								type="password"
+								required
+								minLength={8}
+								autoComplete="new-password"
+								className={inputClassName}
+							/>
+						</div>
+						<div>
+							<label htmlFor="confirmPassword" className={labelClassName}>
+								Confirm Password
+							</label>
+							<input
+								id="confirmPassword"
+								name="confirmPassword"
+								type="password"
+								required
+								minLength={8}
+								autoComplete="new-password"
+								className={inputClassName}
+							/>
+						</div>
+					</div>
+
+					<button
+						type="submit"
+						className="mt-6 w-full rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+					>
+						Create Account
+					</button>
+
+					<p className="mt-4 text-center text-sm text-neutral-600">
+						Already have an account?{" "}
+						<Link
+							href={`/${channel}/login`}
+							className="text-blue-600 hover:text-blue-800"
+						>
+							Log in
+						</Link>
+					</p>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/storefront/src/app/[channel]/(main)/reset-password/actions.ts
+++ b/storefront/src/app/[channel]/(main)/reset-password/actions.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { executeGraphQL } from "@/lib/graphql";
+import { SetPasswordDocument } from "@/gql/graphql";
+import { redirect } from "next/navigation";
+
+export async function resetPasswordAction(channelSlug: string, formData: FormData) {
+	const email = formData.get("email")?.toString() ?? "";
+	const token = formData.get("token")?.toString() ?? "";
+	const password = formData.get("password")?.toString() ?? "";
+	const confirmPassword = formData.get("confirmPassword")?.toString() ?? "";
+
+	if (password !== confirmPassword) {
+		redirect(
+			`/${channelSlug}/reset-password?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}&status=passwords_mismatch`,
+		);
+	}
+
+	if (password.length < 8) {
+		redirect(
+			`/${channelSlug}/reset-password?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}&status=password_too_short`,
+		);
+	}
+
+	let result;
+	try {
+		result = await executeGraphQL(SetPasswordDocument, {
+			variables: { email, password, token },
+			cache: "no-cache",
+			withAuth: false,
+		});
+	} catch {
+		redirect(`/${channelSlug}/reset-password?status=reset_error`);
+	}
+
+	const errors = result.setPassword?.errors ?? [];
+	if (errors.length > 0) {
+		redirect(`/${channelSlug}/reset-password?status=reset_error`);
+	}
+
+	redirect(`/${channelSlug}/login?status=password_reset`);
+}

--- a/storefront/src/app/[channel]/(main)/reset-password/page.tsx
+++ b/storefront/src/app/[channel]/(main)/reset-password/page.tsx
@@ -1,0 +1,111 @@
+import { StatusBanner, type StatusMessage } from "@/ui/components/StatusBanner";
+import { inputClassName, labelClassName } from "../account/styles";
+import { resetPasswordAction } from "./actions";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+const resetMessages: Record<string, StatusMessage> = {
+	passwords_mismatch: { type: "error", text: "Passwords do not match." },
+	password_too_short: { type: "error", text: "Password must be at least 8 characters." },
+	reset_error: { type: "error", text: "Password reset failed. The link may have expired." },
+	invalid_token: { type: "error", text: "Invalid or missing reset token. Please request a new link." },
+};
+
+export default async function ResetPasswordPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ channel: string }>;
+	searchParams: Promise<{ email?: string; token?: string; status?: string }>;
+}) {
+	const { channel } = await params;
+	const { email, token, status } = await searchParams;
+
+	const message = status ? (resetMessages[status] ?? null) : null;
+
+	if (!token) {
+		return (
+			<div className="mx-auto max-w-7xl p-8">
+				<h1 className="text-center text-2xl font-bold tracking-tight text-neutral-900">
+					Reset Password
+				</h1>
+				<StatusBanner message={resetMessages.invalid_token} />
+				<p className="mt-4 text-center text-sm text-neutral-600">
+					<Link
+						href={`/${channel}/forgot-password`}
+						className="text-blue-600 hover:text-blue-800"
+					>
+						Request a new reset link
+					</Link>
+				</p>
+			</div>
+		);
+	}
+
+	const resetWithChannel = resetPasswordAction.bind(null, channel);
+
+	return (
+		<div className="mx-auto max-w-7xl p-8">
+			<h1 className="text-center text-2xl font-bold tracking-tight text-neutral-900">
+				Reset Password
+			</h1>
+
+			<StatusBanner message={message} />
+
+			<div className="mx-auto mt-8 w-full max-w-lg">
+				<form action={resetWithChannel} className="rounded border bg-white p-8 shadow-md">
+					<input type="hidden" name="email" value={email ?? ""} />
+					<input type="hidden" name="token" value={token} />
+
+					<div className="space-y-4">
+						<div>
+							<label htmlFor="password" className={labelClassName}>
+								New Password
+							</label>
+							<input
+								id="password"
+								name="password"
+								type="password"
+								required
+								minLength={8}
+								autoComplete="new-password"
+								className={inputClassName}
+							/>
+						</div>
+						<div>
+							<label htmlFor="confirmPassword" className={labelClassName}>
+								Confirm New Password
+							</label>
+							<input
+								id="confirmPassword"
+								name="confirmPassword"
+								type="password"
+								required
+								minLength={8}
+								autoComplete="new-password"
+								className={inputClassName}
+							/>
+						</div>
+					</div>
+
+					<button
+						type="submit"
+						className="mt-6 w-full rounded bg-neutral-800 px-4 py-2 text-sm text-neutral-200 hover:bg-neutral-700"
+					>
+						Reset Password
+					</button>
+
+					<p className="mt-4 text-center text-sm text-neutral-600">
+						<Link
+							href={`/${channel}/login`}
+							className="text-blue-600 hover:text-blue-800"
+						>
+							Back to login
+						</Link>
+					</p>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/storefront/src/app/singles-builder/[channel]/components/SinglesResults.tsx
+++ b/storefront/src/app/singles-builder/[channel]/components/SinglesResults.tsx
@@ -51,6 +51,7 @@ export function SinglesResults({
 		return () => window.removeEventListener("resize", updateHeight);
 	}, []);
 
+	// eslint-disable-next-line react-hooks/incompatible-library
 	const virtualizer = useVirtualizer({
 		count: products.length,
 		getScrollElement: () => parentRef.current,

--- a/storefront/src/checkout/components/Money.test.tsx
+++ b/storefront/src/checkout/components/Money.test.tsx
@@ -4,22 +4,22 @@ import { Money } from "./Money";
 
 describe("Money component", () => {
 	it("renders formatted money", () => {
-		render(<Money money={{ amount: 9.99, currency: "USD" }} />);
+		render(<Money ariaLabel="Price" money={{ amount: 9.99, currency: "USD" }} />);
 		expect(screen.getByText("$9.99")).toBeInTheDocument();
 	});
 
 	it("renders nothing when money is undefined", () => {
-		const { container } = render(<Money />);
+		const { container } = render(<Money ariaLabel="Price" />);
 		expect(container.innerHTML).toBe("");
 	});
 
 	it("renders nothing when money is null", () => {
-		const { container } = render(<Money money={null} />);
+		const { container } = render(<Money ariaLabel="Price" money={null} />);
 		expect(container.innerHTML).toBe("");
 	});
 
 	it("renders negative amount when negative prop is true", () => {
-		render(<Money money={{ amount: 5.0, currency: "USD" }} negative />);
+		render(<Money ariaLabel="Discount" money={{ amount: 5.0, currency: "USD" }} negative />);
 		expect(screen.getByText("-$5.00")).toBeInTheDocument();
 	});
 
@@ -29,18 +29,18 @@ describe("Money component", () => {
 	});
 
 	it("applies custom className", () => {
-		render(<Money money={{ amount: 10, currency: "USD" }} className="text-bold" />);
+		render(<Money ariaLabel="Price" money={{ amount: 10, currency: "USD" }} className="text-bold" />);
 		const element = screen.getByText("$10.00");
 		expect(element).toHaveClass("text-bold");
 	});
 
 	it("handles large amounts with formatting", () => {
-		render(<Money money={{ amount: 1234.56, currency: "USD" }} />);
+		render(<Money ariaLabel="Price" money={{ amount: 1234.56, currency: "USD" }} />);
 		expect(screen.getByText("$1,234.56")).toBeInTheDocument();
 	});
 
 	it("handles zero amount", () => {
-		render(<Money money={{ amount: 0, currency: "USD" }} />);
+		render(<Money ariaLabel="Price" money={{ amount: 0, currency: "USD" }} />);
 		expect(screen.getByText("$0.00")).toBeInTheDocument();
 	});
 });

--- a/storefront/src/checkout/sections/Summary/SummaryMoneyRow.test.tsx
+++ b/storefront/src/checkout/sections/Summary/SummaryMoneyRow.test.tsx
@@ -4,20 +4,20 @@ import { SummaryMoneyRow } from "./SummaryMoneyRow";
 
 describe("SummaryMoneyRow component", () => {
 	it("renders label and money amount", () => {
-		render(<SummaryMoneyRow label="Subtotal" money={{ amount: 29.99, currency: "USD" }} />);
+		render(<SummaryMoneyRow label="Subtotal" ariaLabel="Subtotal" money={{ amount: 29.99, currency: "USD" }} />);
 		expect(screen.getByText("Subtotal")).toBeInTheDocument();
 		expect(screen.getByText("$29.99")).toBeInTheDocument();
 	});
 
 	it("renders negative money for discounts", () => {
-		render(<SummaryMoneyRow label="Discount" money={{ amount: 5, currency: "USD" }} negative />);
+		render(<SummaryMoneyRow label="Discount" ariaLabel="Discount" money={{ amount: 5, currency: "USD" }} negative />);
 		expect(screen.getByText("Discount")).toBeInTheDocument();
 		expect(screen.getByText("-$5.00")).toBeInTheDocument();
 	});
 
 	it("renders children alongside label", () => {
 		render(
-			<SummaryMoneyRow label="Shipping" money={{ amount: 0, currency: "USD" }}>
+			<SummaryMoneyRow label="Shipping" ariaLabel="Shipping" money={{ amount: 0, currency: "USD" }}>
 				<span data-testid="info-icon">i</span>
 			</SummaryMoneyRow>,
 		);
@@ -26,7 +26,7 @@ describe("SummaryMoneyRow component", () => {
 	});
 
 	it("renders nothing for money when undefined", () => {
-		const { container } = render(<SummaryMoneyRow label="Tax" />);
+		const { container } = render(<SummaryMoneyRow label="Tax" ariaLabel="Tax" />);
 		expect(screen.getByText("Tax")).toBeInTheDocument();
 		// Money component renders nothing when money is undefined
 		const moneyElements = container.querySelectorAll("p[aria-label]");

--- a/storefront/src/graphql/AccountRegister.graphql
+++ b/storefront/src/graphql/AccountRegister.graphql
@@ -1,0 +1,14 @@
+mutation AccountRegister($input: AccountRegisterInput!) {
+	accountRegister(input: $input) {
+		requiresConfirmation
+		user {
+			id
+			email
+		}
+		errors {
+			field
+			message
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/ConfirmEmailChange.graphql
+++ b/storefront/src/graphql/ConfirmEmailChange.graphql
@@ -1,0 +1,13 @@
+mutation ConfirmEmailChange($channel: String!, $token: String!) {
+	confirmEmailChange(channel: $channel, token: $token) {
+		user {
+			id
+			email
+		}
+		errors {
+			field
+			message
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/RequestEmailChange.graphql
+++ b/storefront/src/graphql/RequestEmailChange.graphql
@@ -1,0 +1,13 @@
+mutation RequestEmailChange($channel: String!, $newEmail: String!, $password: String!, $redirectUrl: String!) {
+	requestEmailChange(channel: $channel, newEmail: $newEmail, password: $password, redirectUrl: $redirectUrl) {
+		user {
+			id
+			email
+		}
+		errors {
+			field
+			message
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/RequestPasswordReset.graphql
+++ b/storefront/src/graphql/RequestPasswordReset.graphql
@@ -1,0 +1,9 @@
+mutation RequestPasswordReset($email: String!, $redirectUrl: String!, $channel: String!) {
+	requestPasswordReset(email: $email, redirectUrl: $redirectUrl, channel: $channel) {
+		errors {
+			field
+			message
+			code
+		}
+	}
+}

--- a/storefront/src/graphql/SetPassword.graphql
+++ b/storefront/src/graphql/SetPassword.graphql
@@ -1,0 +1,15 @@
+mutation SetPassword($email: String!, $password: String!, $token: String!) {
+	setPassword(email: $email, password: $password, token: $token) {
+		user {
+			id
+			email
+		}
+		token
+		refreshToken
+		errors {
+			field
+			message
+			code
+		}
+	}
+}

--- a/storefront/src/test/helpers.tsx
+++ b/storefront/src/test/helpers.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 import { render, type RenderOptions } from "@testing-library/react";
+import { vi } from "vitest";
 import { FormContext } from "@/checkout/hooks/useForm/useForm";
 import { type UseFormReturn, type FormDataBase } from "@/checkout/hooks/useForm/types";
 

--- a/storefront/src/ui/components/LoginForm.tsx
+++ b/storefront/src/ui/components/LoginForm.tsx
@@ -1,12 +1,19 @@
+import Link from "next/link";
 import { loginAction } from "./login-actions";
 
-export async function LoginForm({ redirectTo = "/" }: { redirectTo?: string }) {
+export async function LoginForm({
+	redirectTo = "/",
+	channel,
+}: {
+	redirectTo?: string;
+	channel?: string;
+}) {
+	// Extract channel from redirectTo if not explicitly provided
+	const resolvedChannel = channel || extractChannel(redirectTo);
+
 	return (
-		<div className="mx-auto mt-16 w-full max-w-lg">
-			<form
-				className="rounded border p-8 shadow-md"
-				action={loginAction}
-			>
+		<div className="mx-auto mt-8 w-full max-w-lg">
+			<form className="rounded border p-8 shadow-md" action={loginAction}>
 				<input type="hidden" name="redirectTo" value={redirectTo} />
 				<div className="mb-2">
 					<label className="sr-only" htmlFor="email">
@@ -17,6 +24,7 @@ export async function LoginForm({ redirectTo = "/" }: { redirectTo?: string }) {
 						type="email"
 						name="email"
 						placeholder="Email"
+						autoComplete="email"
 						className="w-full rounded border bg-neutral-50 px-4 py-2"
 					/>
 				</div>
@@ -30,18 +38,41 @@ export async function LoginForm({ redirectTo = "/" }: { redirectTo?: string }) {
 						name="password"
 						placeholder="Password"
 						autoCapitalize="off"
-						autoComplete="off"
+						autoComplete="current-password"
 						className="w-full rounded border bg-neutral-50 px-4 py-2"
 					/>
 				</div>
 
 				<button
-					className="rounded bg-neutral-800 px-4 py-2 text-neutral-200 hover:bg-neutral-700"
+					className="w-full rounded bg-neutral-800 px-4 py-2 text-neutral-200 hover:bg-neutral-700"
 					type="submit"
 				>
 					Log In
 				</button>
+
+				{resolvedChannel && (
+					<div className="mt-4 flex items-center justify-between text-sm">
+						<Link
+							href={`/${resolvedChannel}/forgot-password`}
+							className="text-blue-600 hover:text-blue-800"
+						>
+							Forgot password?
+						</Link>
+						<Link
+							href={`/${resolvedChannel}/register`}
+							className="text-blue-600 hover:text-blue-800"
+						>
+							Create an account
+						</Link>
+					</div>
+				)}
 			</form>
 		</div>
 	);
+}
+
+function extractChannel(redirectTo: string): string | null {
+	// redirectTo format: /{channel}/account or /{channel}/...
+	const match = redirectTo.match(/^\/([^/]+)\//);
+	return match ? match[1] : null;
 }


### PR DESCRIPTION
## Summary

Implements the unified account system plan from issue #57. After deep codebase analysis, 6 of 12 original gaps were already implemented — this PR addresses the remaining 8 features across 4 phases.

### Phase 0 — P1 Bug Fixes (inventory-ops)
- **Double-charge prevention**: Idempotency guard in `chargeStoreCredit()` checks for existing charge before deducting
- **Shared credit fix**: All 5 payment webhook handlers use `SHARED_CREDIT_INSTALLATION_ID`

### Phase 1 — Storefront Account Pages
- `/register` — Standalone registration with validation
- `/forgot-password` — Email-enumeration-safe password reset
- `/reset-password` — Token-based reset from email link
- Email change flow on `/account` with POST-based confirmation
- 5 new GraphQL mutation documents with codegen types

### Phase 2 — Backend Features
- **Buylist customer merge** — Serializable credit transfer, buylist reassignment, merge log, source deactivation
- **Tax exemption write-back** — `setTaxExemptMetadata` writes to Saleor metadata, clears stale values

### Phase 3 — Unified Customer View (POS)
- Customer detail shows buylist history, groups, and merge history via parallel fetching

## Test plan
- [ ] `/register` — create account, verify redirect to login
- [ ] `/forgot-password` — submit email, verify confirmation
- [ ] `/account` — expand email change, submit with password
- [ ] POS customer detail — verify buylist/groups/merge sections
- [ ] `setTaxExemptMetadata` — verify metadata in Dashboard
- [ ] Buylist merge — test with credit balances
- [ ] Store credit checkout — verify no double-charge

🤖 Generated with [Claude Code](https://claude.com/claude-code)