### PR TITLE
fix: deploy-staging grep failure on shallow submodule diffs

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -116,13 +116,13 @@ jobs:
           # Lines look like: "diff --git a/saleor-apps/apps/inventory-ops/... b/saleor-apps/apps/inventory-ops/..."
           # The saleor-apps/ prefix (submodule mount point) must be stripped so
           # check_app can match against bare paths like "apps/inventory-ops/".
-          CHANGED_FILES=$(echo "$DIFF" | grep '^diff --git' | sed 's|diff --git a/||; s| b/.*||; s|^saleor-apps/||')
+          CHANGED_FILES=$(echo "$DIFF" | grep '^diff --git' | sed 's|diff --git a/||; s| b/.*||; s|^saleor-apps/||' || true)
 
           # Fallback: if shallow clone couldn't produce file-level diffs,
           # detect nested submodule pointer changes from "Submodule apps/pos OLD..NEW" lines
-          POINTER_CHANGES=$(echo "$DIFF" | grep '^Submodule apps/' | sed 's|^Submodule ||; s| .*||')
+          POINTER_CHANGES=$(echo "$DIFF" | grep '^Submodule apps/' | sed 's|^Submodule ||; s| .*||' || true)
 
-          ALL_CHANGES=$(printf "%s\n%s" "$CHANGED_FILES" "$POINTER_CHANGES" | sort -u | grep -v '^$')
+          ALL_CHANGES=$(printf "%s\n%s" "$CHANGED_FILES" "$POINTER_CHANGES" | sort -u | grep -v '^$' || true)
           echo "Changed files/pointers in submodule:"
           echo "$ALL_CHANGES"
 


### PR DESCRIPTION
## Summary

- Deploy-staging workflow fails at "Detect submodule content changes" when CI shallow clone produces submodule headers without file-level diffs
- `grep '^diff --git'` returns exit 1 (no matches) → kills script under `set -e`
- Fix: add `|| true` to all three grep calls in the submodule detection step

## Root cause

PR #188 merged with submodule pointer changes. In CI's shallow clone, `git diff --submodule=diff HEAD~1 HEAD` produced submodule header lines but no `diff --git` lines, causing grep to exit 1.

## Test plan

- [ ] This PR's own CI passes (proves the workflow doesn't break on the fix commit)
- [ ] Re-run failed deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)