### PR TITLE
fix: POS type annotation + CI type checking (#215)

### DIFF
--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -263,17 +263,22 @@ jobs:
           # Upstream apps (avatax, cms, klaviyo, etc.) have pre-existing lint issues
           pnpm turbo run lint --filter=saleor-app-inventory-ops --filter=saleor-app-pos
 
-      # Type check (tsc --noEmit) skipped for custom apps
-      # Source code compiles clean — remaining errors are in test files only:
-      # - Implicit any types in reduce callbacks (price-sync-router.test.ts)
-      # - Stale mock types in test files (purchase-orders-router.test.ts, goods-receipts-router.test.ts)
-      # TODO: Re-enable after fixing test file types (no source code blockers remain)
-
       - name: Generate Prisma client for inventory-ops
         working-directory: ./saleor-apps/apps/inventory-ops
         run: pnpm prisma generate
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+
+      - name: Generate Prisma client for POS
+        working-directory: ./saleor-apps/apps/pos
+        run: pnpm prisma generate
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+
+      - name: Type check custom apps
+        run: |
+          # Matches Docker build behavior — catches TS errors before deploy
+          pnpm turbo run check-types --filter=saleor-app-inventory-ops --filter=saleor-app-pos
 
       - name: Run tests
         run: pnpm test:ci


### PR DESCRIPTION
## Summary

- **POS type annotation**: adds `(c: (typeof creditBalances)[number])` to `customers-router.ts:200` — fixes `noImplicitAny` error that causes Docker build failure
- **CI type checking**: replaces skipped `tsc --noEmit` comment with actual `check-types` step for both POS and inventory-ops in `test-platform.yml`
- **Prisma generate for POS in CI**: adds POS prisma generate step (was only generating for inventory-ops)

## Root Cause

PR #214 fixed the prisma-json-types-generator dependency and the inventory-ops type error, but **missed the POS type annotation**. The commit `ae2670c` only added `package.json` dep, never the TS fix. Every deploy since has failed on this same error.

The systemic issue: `test-platform.yml` lines 266-270 explicitly skipped TypeScript checking with a comment claiming "no source code blockers remain" — but that was never verified. Docker builds run `next build` which includes TS compilation, creating a gap where broken code passes CI but fails at deploy.

## Test plan

- [ ] `test-platform` CI passes (includes new `check-types` step)
- [ ] POS Docker build succeeds in deploy-staging
- [ ] Inventory-ops Docker build succeeds in deploy-staging
- [ ] Both apps deploy to staging successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)