### PR TITLE
ci: use next build instead of tsc for type checking (#216)

### DIFF
--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -275,10 +275,16 @@ jobs:
         env:
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
 
-      - name: Type check custom apps
+      - name: Build custom apps (type check + compile)
         run: |
-          # Matches Docker build behavior — catches TS errors before deploy
-          pnpm turbo run check-types --filter=saleor-app-inventory-ops --filter=saleor-app-pos
+          # Runs `next build` which includes TypeScript compilation.
+          # Matches Docker build behavior exactly — catches TS errors before deploy.
+          # Note: `tsc --noEmit` cannot be used because prisma-json-types-generator
+          # produces broken .d.ts syntax (unclosed array brackets in generated types).
+          # next build handles this via its own compilation pipeline.
+          SKIP_ENV_VALIDATION=true pnpm turbo run build --filter=saleor-app-inventory-ops --filter=saleor-app-pos
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
 
       - name: Run tests
         run: pnpm test:ci


### PR DESCRIPTION
## Summary

- Switches CI type checking from `tsc --noEmit` (check-types) to `next build` (build) for custom apps

## Why

PR #215 added `check-types` to CI, but `prisma-json-types-generator` 3.0.4 produces broken `.d.ts` syntax — unclosed array brackets like `PrismaJson.PriceChangeEntry[` instead of `PrismaJson.PriceChangeEntry[]`. This causes `tsc` to fail with parse errors that even `skipLibCheck` can't skip (they're syntax errors, not type errors).

`next build` uses its own TypeScript compilation pipeline that handles this, and it matches exactly what the Docker build does — so if CI passes, deploy will too.

## Test plan

- [ ] `test-platform` CI passes with the build step
- [ ] Custom apps build successfully in the Apps Checks job

🤖 Generated with [Claude Code](https://claude.com/claude-code)