### PR TITLE
fix: add dashboard to ALLOWED_CLIENT_HOSTS

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -404,7 +404,7 @@ module "ecs" {
   media_bucket_name = module.s3.bucket_name
   # Saleor's AWS_MEDIA_CUSTOM_DOMAIN expects domain only (no https://), not full URL
   media_cdn_url   = var.enable_cloudfront ? module.cloudfront[0].domain_name : ""
-  allowed_hosts   = "api.${var.domain_name},localhost,${module.alb.alb_dns_name}"
+  allowed_hosts   = "api.${var.domain_name},dashboard.${var.domain_name},localhost,${module.alb.alb_dns_name}"
   meilisearch_url = var.meilisearch_enabled ? module.meilisearch[0].service_url : "http://meilisearch.${local.name_prefix}.local:7700"
   # Pass Meilisearch API key secret ARN to storefront for authenticated requests
   meilisearch_api_key_secret_arn = var.meilisearch_enabled ? aws_secretsmanager_secret.meilisearch_master_key[0].arn : ""


### PR DESCRIPTION
## Summary

- `dashboard.staging.michaelbean.org` was missing from Saleor's `ALLOWED_CLIENT_HOSTS`
- This caused "is not allowed" error when Dashboard tried to invite staff members
- One-line fix in `infra/terraform/main.tf` — adds `dashboard.${var.domain_name}` to the allowed hosts list

**Requires `terraform apply` after merge to update the ECS task definition.**

## Test plan

- [ ] Terraform plan shows only env var change on API/worker tasks
- [ ] After apply, Dashboard can successfully invite staff members

🤖 Generated with [Claude Code](https://claude.com/claude-code)